### PR TITLE
Minor fixes, refactors, and formatting

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,6 +36,7 @@ rustflags = [
     "-Wclippy::todo",
     "-Wunused_crate_dependencies",
     "-Wmissing_debug_implementations",
+    "-Wclippy::missing_assert_message",
 
     # Manual debugging
     # Prefer tracing::trace!() or tracing::debug!()
@@ -50,4 +51,14 @@ rustflags = [
     # Documentation
     "-Wmissing_docs",
     "-Wclippy::missing_docs_in_private_items",
+
+    # Testing and debugging
+    "-Wclippy::assertions_on_result_states",
+    "-Wclippy::debug_assert_with_mut_call",
+
+    # Style
+    "-Wclippy::from_iter_instead_of_collect",
+    "-Wclippy::inconsistent_struct_constructor",
+    "-Wclippy::manual_assert",
+    "-Wclippy::needless_pass_by_value",
 ]

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ Important event alerts for Subspace blockchains.
 ## Limitations (PoC)
 
 - Hardcoded Slack channel, workspace ID, and thresholds.
-- Minimal decoding/validation for some extrinsics; fields are parsed best-effort.
+- Minimal decoding/validation for extrinsics and events; fields are parsed best-effort.
 - Minimal stateful aggregation (e.g., summing multiple related transfers)
 - No alert deduplication when multiple instances are running.
 - Limited CLI configuration.
 - No persistent storage, no metrics, no dashboards.
 - Basic error handling: logs warnings on transient decode/metadata mismatches and continues.
+- Limited testing, some tests are still manual.
 
 ## Getting started
 
@@ -60,6 +61,7 @@ Important event alerts for Subspace blockchains.
 
 - Crate `chain-alerter`
   - `alerts.rs`: checks for alerts in each block and extrinsic
+  - `slot_time_monitor.rs`: slot production rate monitoring for slot alerts
   - `subspace.rs`: Uses `subxt` and `scale-value` for chain interaction
   - `slack.rs`: Uses `slack-morphism` to send messages to Slack
   - `main.rs`: main process logic and run loop

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -30,7 +30,7 @@ const MIN_BALANCE_CHANGE: u128 = 1_000_000_000 * AI3;
 const MIN_BLOCK_GAP: Duration = Duration::from_secs(60);
 
 /// A blockchain alert with context.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Alert {
     /// The type of alert.
     pub alert: AlertKind,
@@ -47,7 +47,7 @@ impl Alert {
 }
 
 /// The type of alert.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AlertKind {
     /// The alerter has started.
     Startup,
@@ -110,10 +110,10 @@ pub enum AlertKind {
     /// A slot time alert has been detected.
     SlotTimeAlert {
         /// The current ratio of slots to time.
-        current_ratio: String,
+        current_ratio: f64,
 
         /// The applicable threshold for this alert.
-        threshold: String,
+        threshold: f64,
 
         /// The duration of the interval.
         interval: Duration,

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -55,12 +55,16 @@ pub enum AlertKind {
     /// Block production has stalled.
     BlockProductionStall {
         /// The gap between the previous block and now.
+        ///
+        /// Note: the previous block is `Alert.block_info`.
         gap: Option<Duration>,
     },
 
     /// Block production has resumed.
     BlockProductionResumed {
         /// The gap between the previous and current block.
+        ///
+        /// Note: the current block is `Alert.block_info`.
         gap: Duration,
 
         /// The previous block.

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -209,11 +209,9 @@ impl Display for AlertKind {
                 write!(
                     f,
                     "**Slot per time ratio alert**\n\
-                    Current ratio: {} slots per second\n\
-                    Threshold: {} slots per second\n\
-                    Interval: {} seconds",
-                    current_ratio,
-                    threshold,
+                    Current ratio: {current_ratio:.2} slots per second\n\
+                    Threshold: {threshold:.2} slots per second\n\
+                    Interval: {}",
                     fmt_duration(*interval),
                 )
             }

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -228,8 +228,7 @@ pub async fn startup_alert(
 ) -> anyhow::Result<()> {
     // TODO:
     // - always post this to the test channel, because it's not a real "alert"
-    // - link to the prod channel from this message:
-    //   <https://docs.slack.dev/messaging/formatting-message-text/#linking-channels>
+    // - link to the prod channel from this message: <https://docs.slack.dev/messaging/formatting-message-text/#linking-channels>
 
     alert_tx
         .send(Alert::new(AlertKind::Startup, *block_info))
@@ -360,10 +359,10 @@ where
         // subxt knows these field names, so we can search for the transfer value by
         // name.
         // TODO:
-        // - track the total of recent transfers, so the threshold can't be bypassed by
-        //   splitting the transfer into multiple calls
-        // - split this field search into a function which takes a field name,
-        //   and another function which does the numeric conversion and range check
+        // - track the total of recent transfers, so the threshold can't be bypassed by splitting
+        //   the transfer into multiple calls
+        // - split this field search into a function which takes a field name, and another function
+        //   which does the numeric conversion and range check
         let transfer_value = if let Composite::Named(named_fields) = &extrinsic_info.fields
             && let Some((_, transfer_value)) = named_fields
                 .iter()

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -135,6 +135,7 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
             interval: Duration::from_secs(1),
         }
     );
+    assert_eq!(alert.block_info, second_block);
 
     Ok(())
 }

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -151,8 +151,8 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
     assert_eq!(
         alert.alert,
         AlertKind::SlotTimeAlert {
-            current_ratio: "0.01".to_string(),
-            threshold: "0".to_string(),
+            current_ratio: 0.01,
+            threshold: 0.0,
             interval: Duration::from_secs(1),
         }
     );

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -3,16 +3,15 @@
 //! Set the `NODE_URL` env var to the RPC URL of a Subspace node to override the default public
 //! instance.
 
-use crate::slot_time_monitor::test_utils::mock_block_info;
-use std::time::Duration;
-
 use crate::alerts::{self, AlertKind};
+use crate::slot_time_monitor::test_utils::mock_block_info;
 use crate::slot_time_monitor::{MemorySlotTimeMonitor, SlotTimeMonitor, SlotTimeMonitorConfig};
 use crate::subspace::tests::{
     decode_event, decode_extrinsic, fetch_block_info, node_rpc_url, test_setup,
 };
 use crate::subspace::{BlockNumber, Slot};
 use anyhow::Ok;
+use std::time::Duration;
 use subxt::utils::H256;
 
 /// The raw block hash literal type.
@@ -104,7 +103,8 @@ async fn no_expected_test_slot_time_alert() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check that the slot time alert is triggered when the time per slot is above the threshold and has elapsed enough time.
+/// Check that the slot time alert is triggered when the time per slot is above the threshold and
+/// has elapsed enough time.
 #[tokio::test(flavor = "multi_thread")]
 async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
     let (_, alert_tx, mut alert_rx, _update_task) = test_setup(node_rpc_url()).await?;
@@ -140,7 +140,8 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check that the slot time alert is not triggered when the time per slot is above the threshold but has not elapsed enough time.
+/// Check that the slot time alert is not triggered when the time per slot is above the threshold
+/// but has not elapsed enough time.
 #[tokio::test(flavor = "multi_thread")]
 async fn expected_test_slot_time_alert_but_not_yet() -> anyhow::Result<()> {
     let (_, alert_tx, mut alert_rx, _update_task) = test_setup(node_rpc_url()).await?;

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -128,8 +128,8 @@ async fn run() -> anyhow::Result<()> {
     // A channel that shares the latest block info with concurrently running tasks.
     let latest_block_tx = watch::Sender::new(None);
 
-    // Subscribe to best blocks (before they are finalized, because finalization can take hours or days).
-    // TODO: do we need to subscribe to all blocks from all forks here?
+    // Subscribe to best blocks (before they are finalized, because finalization can take hours or
+    // days). TODO: do we need to subscribe to all blocks from all forks here?
     let mut blocks_sub = chain_client.blocks().subscribe_best().await?;
 
     // Slot time monitor is used to check if the slot time is within the expected range.

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -148,7 +148,7 @@ async fn run() -> anyhow::Result<()> {
         let block_info = BlockInfo::new(&block, &extrinsics, &genesis_hash);
 
         // Notify spawned tasks that a new block has arrived.
-        latest_block_tx.send_replace(Some(block_info.clone()));
+        latest_block_tx.send_replace(Some(block_info));
 
         if first_block {
             alerts::startup_alert(&alert_tx, &block_info).await?;
@@ -165,12 +165,8 @@ async fn run() -> anyhow::Result<()> {
         }
 
         // Check for block stalls, and check the block itself for alerts.
-        alerts::check_for_block_stall(
-            alert_tx.clone(),
-            block_info.clone(),
-            latest_block_tx.subscribe(),
-        )
-        .await;
+        alerts::check_for_block_stall(alert_tx.clone(), block_info, latest_block_tx.subscribe())
+            .await;
 
         alerts::check_block(&alert_tx, &block_info, &prev_block_info).await?;
         slot_time_monitor.process_block(&block_info).await;

--- a/chain-alerter/src/slack.rs
+++ b/chain-alerter/src/slack.rs
@@ -144,12 +144,11 @@ impl SlackSecret {
             const USER_READ_WRITE: u32 = 0o600;
 
             let secret_perms = fs::metadata(path).await?.permissions().mode();
-            if secret_perms & 0o777 != USER_READ_ONLY && secret_perms & 0o777 != USER_READ_WRITE {
-                panic!(
-                    "slack-oauth-secret must be readable only by the user running this process \
-                    ({USER_READ_ONLY:?} or {USER_READ_WRITE:?}), but it is {secret_perms:?}"
-                );
-            }
+            assert!(
+                secret_perms & 0o777 == USER_READ_ONLY || secret_perms & 0o777 == USER_READ_WRITE,
+                "slack-oauth-secret must be readable only by the user running this process \
+                ({USER_READ_ONLY:?} or {USER_READ_WRITE:?}), but it is {secret_perms:?}"
+            );
         }
 
         let secret = fs::read_to_string(path).await?;

--- a/chain-alerter/src/slack.rs
+++ b/chain-alerter/src/slack.rs
@@ -104,6 +104,7 @@ struct SlackSecret(SlackApiToken);
 
 impl Deref for SlackSecret {
     type Target = SlackApiToken;
+
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -10,7 +10,6 @@ use crate::alerts::{Alert, AlertKind};
 use crate::subspace::{BlockInfo, BlockTime, Slot};
 use std::time::Duration;
 use tokio::sync::mpsc::error::SendError;
-
 use tracing::{debug, info, warn};
 
 /// The default threshold for the slot time alert.

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -2,6 +2,7 @@
 //!
 //! This module tracks Subspace slot progression and checks whether observed slot timings
 //! exceed configured thresholds.
+
 #[cfg(test)]
 pub mod test_utils;
 

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -140,8 +140,8 @@ impl MemorySlotTimeMonitor {
             .alert_tx
             .send(Alert {
                 alert: AlertKind::SlotTimeAlert {
-                    current_ratio: slot_diff_per_time_diff.to_string(),
-                    threshold: self.config.alert_threshold.to_string(),
+                    current_ratio: slot_diff_per_time_diff,
+                    threshold: self.config.alert_threshold,
                     interval: self.config.check_interval,
                 },
                 block_info,

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -350,8 +350,8 @@ impl EventInfo {
     }
 }
 
-/// Calculates the timestamp gap between a block and a later time, if the block is present and has a timestamp.
-/// Returns `None` if the block info is missing, or the block is missing a timestamp.
+/// Calculates the timestamp gap between a block and a later time, if the block is present and has a
+/// timestamp. Returns `None` if the block info is missing, or the block is missing a timestamp.
 pub fn gap_since_time(
     latest_time: DateTime<Utc>,
     prev_block_info: impl Into<Option<BlockInfo>>,
@@ -403,6 +403,11 @@ impl Sub<u64> for Slot {
 }
 
 impl Slot {
+    /// The length of the slot number in bytes.
+    const SLOT_LEN: usize = 4;
+    /// The offset of the slot number in the pre-runtime digest.
+    const SLOT_OFFSET: usize = 1;
+
     /// Create a new slot from a block.
     pub fn new<Client>(block: &Block<SubspaceConfig, Client>) -> Option<Slot>
     where
@@ -424,12 +429,6 @@ impl Slot {
 
         result.map(Slot)
     }
-
-    /// The offset of the slot number in the pre-runtime digest.
-    const SLOT_OFFSET: usize = 1;
-
-    /// The length of the slot number in bytes.
-    const SLOT_LEN: usize = 4;
 
     /// Decodes the slot number from a pre-runtime digest.
     fn decode_slot_number(pre_digest: Vec<u8>) -> Option<u64> {

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -75,7 +75,7 @@ pub async fn spawn_metadata_update_task(chain_client: &SubspaceClient) -> AsyncJ
 }
 
 /// Block info that can be formatted.
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct BlockInfo {
     /// The block number.
     pub block_height: BlockNumber,
@@ -133,7 +133,7 @@ impl BlockInfo {
 }
 
 /// A block time formatted different ways.
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct BlockTime {
     /// The block UNIX time (in milliseconds).
     pub unix_time: u128,
@@ -371,7 +371,7 @@ pub fn gap_since_last_block(
 }
 
 /// A Subspace block slot.
-#[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Copy)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Slot(pub u64);
 
 impl Display for Slot {

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -19,10 +19,6 @@ use subxt::utils::H256;
 use subxt::{OnlineClient, SubstrateConfig};
 use tracing::{debug, info, trace, warn};
 
-/// The Subspace block height type.
-/// Copied from subspace-core-primitives.
-pub type BlockNumber = u32;
-
 /// One Subspace Credit.
 /// Copied from subspace-runtime-primitives.
 pub const AI3: u128 = 10_u128.pow(18);
@@ -38,12 +34,22 @@ pub const FOUNDATION_SUBSPACE_NODE_URL: &str = "wss://rpc.mainnet.subspace.found
 #[allow(dead_code)]
 pub const LABS_SUBSPACE_NODE_URL: &str = "wss://rpc-0.mainnet.autonomys.xyz/ws";
 
+/// The Subspace block height type.
+/// Copied from subspace-core-primitives.
+pub type BlockNumber = u32;
+
 /// The config for basic Subspace block and extrinsic types.
 /// TODO: create a custom SubspaceConfig type
 pub type SubspaceConfig = SubstrateConfig;
 
 /// The type of Subspace client we're using.
 pub type SubspaceClient = OnlineClient<SubspaceConfig>;
+
+/// The Subspace/subxt extrinsic index type.
+pub type ExtrinsicIndex = u32;
+
+/// The Subspace/subxt event index type.
+pub type EventIndex = u32;
 
 /// Create a new Subspace client.
 pub async fn create_subspace_client(
@@ -207,13 +213,13 @@ pub struct ExtrinsicInfo {
     pub call: String,
 
     /// The extrinsic index.
-    pub index: u32,
+    pub index: ExtrinsicIndex,
 
     /// The extrinsic hash.
     pub hash: H256,
 
     /// The extrinsic fields, with the extrinsic index as a context.
-    pub fields: Composite<u32>,
+    pub fields: Composite<ExtrinsicIndex>,
 }
 
 impl Display for ExtrinsicInfo {
@@ -289,13 +295,13 @@ pub struct EventInfo {
     pub kind: String,
 
     /// The event index in the block.
-    pub index: u32,
+    pub index: EventIndex,
 
     /// The phase the event was emitted in.
     pub phase: Phase,
 
     /// The event fields, with the event index as a context.
-    pub fields: Composite<u32>,
+    pub fields: Composite<EventIndex>,
 }
 
 impl Display for EventInfo {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,23 @@
 edition = "2024"
+unstable_features = true
+newline_style = "Unix"
+
 imports_granularity = "Module"
+group_imports = "One"
+reorder_impl_items = true
+
+comment_width = 100
+format_code_in_doc_comments = true
+normalize_comments = true
+normalize_doc_attributes = true
+wrap_comments = true
+
+format_macro_matchers = true
+# Turning this on makes some strings harder to read.
+format_strings = false
+hex_literal_case = "Lower"
+# Missing from nightly Rust:
+# <https://github.com/rust-lang/rustfmt/issues/6471>
+#float_literal_trailing_zero = "Always"
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
This PR makes some refactors across the codebase:
- new clippy lints
- extra rustfmt settings
- documentation and comments, update README
- split out test helper functions
- use named module style, rather than legacy mod.rs style

And some minor changes:
- use f64 (to 2 decimal places) in slot alerts
- add a missing test assert for the block info
