### PR TITLE
Handle block chain gaps in the alerter

### DIFF
--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -330,7 +330,6 @@ pub async fn check_block(
     // Because it depends on the next block, this check logs after block production resumes.
     if let Some(gap) = gap_since_last_block(*block_info, *prev_block_info) {
         // If there was a real gap in the chain of blocks, skip this alert.
-        // TODO: spawn a task to check skipped blocks
         if gap >= MIN_BLOCK_GAP && block_info.block_height == prev_block_info.block_height + 1 {
             alert_tx
                 .send(Alert::new(

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -369,7 +369,7 @@ pub async fn check_for_block_stall(
         sleep(MIN_BLOCK_GAP).await;
 
         // Avoid a potential deadlock by copying the watched value immediately.
-        let latest_block_info = latest_block_rx
+        let latest_block_info: BlockInfo = latest_block_rx
             .borrow()
             .expect("never empty, a block is sent before spawning this task");
 

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -228,7 +228,7 @@ impl Display for AlertKind {
 
 impl AlertKind {
     /// Extract the previous block from the alert, if present.
-    #[expect(dead_code, reason = "TODO: use in tests")]
+    #[allow(dead_code, reason = "TODO: use in tests")]
     pub fn prev_block_info(&self) -> Option<&BlockInfo> {
         match self {
             AlertKind::BlockProductionResumed {
@@ -248,7 +248,7 @@ impl AlertKind {
     }
 
     /// Extract the extrinsic from the alert, if present.
-    #[allow(dead_code, reason = "only used in tests")]
+    #[cfg_attr(not(test), allow(dead_code, reason = "only used in tests"))]
     pub fn extrinsic_info(&self) -> Option<&ExtrinsicInfo> {
         match self {
             AlertKind::ForceBalanceTransfer { extrinsic_info, .. } => Some(extrinsic_info),
@@ -264,7 +264,7 @@ impl AlertKind {
     }
 
     /// Extract the transfer value from the alert, if present.
-    #[expect(dead_code, reason = "TODO: use in tests")]
+    #[allow(dead_code, reason = "TODO: use in tests")]
     pub fn transfer_value(&self) -> Option<Balance> {
         match self {
             AlertKind::ForceBalanceTransfer { transfer_value, .. } => *transfer_value,
@@ -280,7 +280,7 @@ impl AlertKind {
     }
 
     /// Extract the event from the alert, if present.
-    #[allow(dead_code, reason = "only used in tests")]
+    #[cfg_attr(not(test), allow(dead_code, reason = "only used in tests"))]
     pub fn event_info(&self) -> Option<&EventInfo> {
         match self {
             AlertKind::SudoEvent { event_info } => Some(event_info),

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -329,7 +329,9 @@ pub async fn check_block(
 
     // Because it depends on the next block, this check logs after block production resumes.
     if let Some(gap) = gap_since_last_block(*block_info, *prev_block_info) {
-        if gap >= MIN_BLOCK_GAP {
+        // If there was a real gap in the chain of blocks, skip this alert.
+        // TODO: spawn a task to check skipped blocks
+        if gap >= MIN_BLOCK_GAP && block_info.block_height == prev_block_info.block_height + 1 {
             alert_tx
                 .send(Alert::new(
                     AlertKind::BlockProductionResumed {

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -3,7 +3,7 @@
 //! Set the `NODE_URL` env var to the RPC URL of a Subspace node to override the default public
 //! instance.
 
-use crate::alerts::{self, AlertKind, BlockCheckMode};
+use crate::alerts::{self, Alert, AlertKind, BlockCheckMode};
 use crate::slot_time_monitor::test_utils::mock_block_info;
 use crate::slot_time_monitor::{MemorySlotTimeMonitor, SlotTimeMonitor, SlotTimeMonitorConfig};
 use crate::subspace::tests::{
@@ -63,10 +63,12 @@ async fn test_startup_alert() -> anyhow::Result<()> {
 
     let (block_info, _, _) = fetch_block_info(&subspace_client, None, None).await?;
 
-    alerts::startup_alert(&alert_tx, &block_info).await?;
+    alerts::startup_alert(BlockCheckMode::Current, &alert_tx, &block_info).await?;
     let alert = alert_rx.try_recv().expect("no alert received");
-    assert_eq!(alert.alert, AlertKind::Startup);
-    assert_eq!(alert.block_info, block_info);
+    assert_eq!(
+        alert,
+        Alert::new(AlertKind::Startup, block_info, BlockCheckMode::Current),
+    );
 
     // Check block slot parsing works on real blocks.
     assert_matches!(alert.block_info.block_slot, Some(Slot(_)));
@@ -88,7 +90,14 @@ async fn test_sudo_alerts() -> anyhow::Result<()> {
 
     alerts::check_extrinsic(BlockCheckMode::Replay, &alert_tx, &extrinsic, &block_info).await?;
     let alert = alert_rx.try_recv().expect("no alert received");
-    assert_eq!(alert.alert, AlertKind::SudoCall { extrinsic_info });
+    assert_eq!(
+        alert,
+        Alert::new(
+            AlertKind::SudoCall { extrinsic_info },
+            block_info,
+            BlockCheckMode::Replay,
+        )
+    );
     assert_eq!(
         alert
             .alert
@@ -96,13 +105,19 @@ async fn test_sudo_alerts() -> anyhow::Result<()> {
             .map(|ei| (ei.pallet.as_str(), ei.call.as_str())),
         Some(("Sudo", "sudo"))
     );
-    assert_eq!(alert.block_info, block_info);
 
     let (event, event_info) = decode_event(&block_info, &events, SUDO_BLOCK.3).await?;
 
     alerts::check_event(BlockCheckMode::Replay, &alert_tx, &event, &block_info).await?;
     let alert = alert_rx.try_recv().expect("no alert received");
-    assert_eq!(alert.alert, AlertKind::SudoEvent { event_info });
+    assert_eq!(
+        alert,
+        Alert::new(
+            AlertKind::SudoEvent { event_info },
+            block_info,
+            BlockCheckMode::Replay,
+        )
+    );
     assert_eq!(
         alert
             .alert
@@ -110,7 +125,6 @@ async fn test_sudo_alerts() -> anyhow::Result<()> {
             .map(|ei| (ei.pallet.as_str(), ei.kind.as_str())),
         Some(("Sudo", "Sudid"))
     );
-    assert_eq!(alert.block_info, block_info);
 
     // Check block slot parsing works on a known slot value.
     assert_eq!(alert.block_info.block_slot, Some(SUDO_BLOCK.4));
@@ -134,13 +148,16 @@ async fn test_large_balance_transfer_alerts() -> anyhow::Result<()> {
         alerts::check_extrinsic(BlockCheckMode::Replay, &alert_tx, &extrinsic, &block_info).await?;
         let alert = alert_rx.try_recv().expect("no alert received");
         assert_eq!(
-            alert.alert,
-            AlertKind::LargeBalanceTransfer {
-                extrinsic_info,
-                transfer_value,
-            }
+            alert,
+            Alert::new(
+                AlertKind::LargeBalanceTransfer {
+                    extrinsic_info,
+                    transfer_value,
+                },
+                block_info,
+                BlockCheckMode::Replay,
+            )
         );
-        assert_eq!(alert.block_info, block_info);
 
         // Check block slot parsing works on a known slot value.
         assert_eq!(alert.block_info.block_slot, Some(slot));
@@ -208,17 +225,20 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
         .expect("alert not received when expected");
 
     assert_eq!(
-        alert.alert,
-        AlertKind::SlotTime {
-            current_ratio: 0.01,
-            threshold: 0.0,
-            interval: Duration::from_secs(1),
-            first_slot_time: first_block
-                .block_time
-                .expect("block must have time to trigger alert"),
-        }
+        alert,
+        Alert::new(
+            AlertKind::SlotTime {
+                current_ratio: 0.01,
+                threshold: 0.0,
+                interval: Duration::from_secs(1),
+                first_slot_time: first_block
+                    .block_time
+                    .expect("block must have time to trigger alert"),
+            },
+            second_block,
+            BlockCheckMode::Replay,
+        )
     );
-    assert_eq!(alert.block_info, second_block);
 
     Ok(())
 }

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -150,7 +150,7 @@ async fn run() -> anyhow::Result<()> {
         let block_info = BlockInfo::new(&block, &extrinsics, &genesis_hash);
 
         if first_block {
-            alerts::startup_alert(&alert_tx, &block_info).await?;
+            alerts::startup_alert(BlockCheckMode::Current, &alert_tx, &block_info).await?;
             first_block = false;
         } else if block_info
             .block_height
@@ -187,6 +187,7 @@ async fn run() -> anyhow::Result<()> {
 
             // We only check for block stalls on current blocks.
             alerts::check_for_block_stall(
+                BlockCheckMode::Current,
                 alert_tx.clone(),
                 block_info,
                 latest_block_tx.subscribe(),

--- a/chain-alerter/src/slack.rs
+++ b/chain-alerter/src/slack.rs
@@ -304,14 +304,20 @@ impl SlackClientInfo {
             self.channel_id,
         );
 
+        let Alert {
+            alert,
+            block_info,
+            mode,
+        } = alert;
+
         // Format the message as Slack message blocks:
         // <https://api.slack.com/reference/block-kit/blocks>
         let mut message_blocks: Vec<SlackBlock> = vec![];
-        message_blocks.push(SlackMarkdownBlock::new(format!("{}", alert.alert)).into());
+        message_blocks.push(SlackMarkdownBlock::new(format!("{alert}")).into());
         message_blocks.push(SlackDividerBlock::new().into());
         message_blocks.push(
             SlackContextBlock::new(vec![
-                SlackBlockPlainText::new(format!("{}", alert.block_info)).into(),
+                SlackBlockPlainText::new(format!("{mode:?}\n{block_info}")).into(),
             ])
             .into(),
         );

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -123,7 +123,7 @@ impl SlotTimeMonitor for MemorySlotTimeMonitor {
                             ?mode,
                             "Time per slot alert triggered, time_per_slot: {time_per_slot}",
                         );
-                        let _ = self.send_alert(time_per_slot, *block_info).await;
+                        let _ = self.send_alert(time_per_slot, *block_info, mode).await;
                     } else {
                         debug!(
                             ?mode,
@@ -162,11 +162,12 @@ impl MemorySlotTimeMonitor {
         &self,
         slot_diff_per_time_diff: f64,
         block_info: BlockInfo,
+        mode: BlockCheckMode,
     ) -> Result<(), SendError<Alert>> {
         self.config
             .alert_tx
-            .send(Alert {
-                alert: AlertKind::SlotTime {
+            .send(Alert::new(
+                AlertKind::SlotTime {
                     current_ratio: slot_diff_per_time_diff,
                     threshold: self.config.alert_threshold,
                     interval: self.config.check_interval,
@@ -176,7 +177,8 @@ impl MemorySlotTimeMonitor {
                         .first_slot_time,
                 },
                 block_info,
-            })
+                mode,
+            ))
             .await
     }
 

--- a/chain-alerter/src/slot_time_monitor/test_utils.rs
+++ b/chain-alerter/src/slot_time_monitor/test_utils.rs
@@ -8,6 +8,7 @@ pub fn mock_block_info(time: RawTime, slot: Slot) -> BlockInfo {
         block_height: 100,
         block_time: Some(BlockTime { unix_time: time }),
         block_hash: H256::zero(),
+        parent_hash: H256::zero(),
         genesis_hash: H256::zero(),
         block_slot: Some(slot),
     }

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -116,25 +116,36 @@ pub struct BlockInfo {
 
 impl Display for BlockInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Block Height: {}", self.block_height)?;
+        let Self {
+            block_height,
+            block_time,
+            block_hash,
+            // Skip the parent hash because it's too verbose in alerts.
+            parent_hash: _,
+            genesis_hash,
+            block_slot,
+        } = self;
+
+        writeln!(f, "Block Height: {block_height}")?;
         writeln!(
             f,
             "Time: {}",
-            self.block_time
+            block_time
                 .as_ref()
                 .map(|bt| bt.to_string())
                 .unwrap_or_else(|| "unknown".to_string())
         )?;
         // Show full block hash but truncated genesis hash.
-        writeln!(f, "Hash: {:?}", self.block_hash)?;
+        writeln!(f, "Hash: {block_hash:?}")?;
         writeln!(
             f,
             "Slot: {}",
-            self.block_slot
+            block_slot
                 .map(|bs| bs.to_string())
                 .unwrap_or_else(|| "unknown".to_string())
         )?;
-        write!(f, "Genesis: {}", self.genesis_hash)?;
+        write!(f, "Genesis: {genesis_hash}")?;
+
         Ok(())
     }
 }
@@ -248,13 +259,18 @@ pub struct ExtrinsicInfo {
 
 impl Display for ExtrinsicInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            f,
-            "Extrinsic {}::{} (index {})",
-            self.pallet, self.call, self.index
-        )?;
-        writeln!(f, "Hash: {:?}", self.hash)?;
-        write!(f, "{}", self.fields_str())?;
+        let Self {
+            pallet,
+            call,
+            index,
+            hash,
+            fields,
+        } = self;
+
+        writeln!(f, "Extrinsic {pallet}::{call} (index {index})")?;
+        writeln!(f, "Hash: {hash:?}")?;
+        write!(f, "{}", fmt_fields(fields))?;
+
         Ok(())
     }
 }
@@ -330,13 +346,18 @@ pub struct EventInfo {
 
 impl Display for EventInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(
-            f,
-            "Event {}::{} (index {})",
-            self.pallet, self.kind, self.index
-        )?;
-        writeln!(f, "Phase: {:?}", self.phase)?;
-        write!(f, "{}", self.fields_str())?;
+        let Self {
+            pallet,
+            kind,
+            index,
+            phase,
+            fields,
+        } = self;
+
+        writeln!(f, "Event {pallet}::{kind} (index {index})")?;
+        writeln!(f, "Phase: {phase:?}")?;
+        write!(f, "{}", fmt_fields(fields))?;
+
         Ok(())
     }
 }

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -104,6 +104,9 @@ pub struct BlockInfo {
     /// The block hash.
     pub block_hash: H256,
 
+    /// The parent block hash.
+    pub parent_hash: H256,
+
     /// The genesis block hash for this network.
     pub genesis_hash: H256,
 
@@ -151,6 +154,7 @@ impl BlockInfo {
             block_time: BlockTime::new(extrinsics),
             block_slot: Slot::new(block),
             block_hash: block.hash(),
+            parent_hash: block.header().parent_hash,
             genesis_hash: *genesis_hash,
         }
     }


### PR DESCRIPTION
This PR handles block chain gaps in the alerter subscription by:
- ignoring block stall alerts when there are gaps in the subscribed chain
- walking block chain gaps backwards until we reach the start height

This involves some significant refactors to the main module, so we can call block checks from multiple places.

~~Currently this PR only logs the missed blocks we want to check, the actual checks are coming in my next PR.~~

Part of #26