### PR TITLE
Make RPC client reconnect with exponential backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "finito"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2384245d85162258a14b43567a9ee3598f5ae746a1581fb5d3d2cb780f0dbf95"
+dependencies = [
+ "futures-timer",
+ "pin-project",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3798,6 +3808,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25de7727144780d780a6a7d78bbfd28414b8adbab68b05e87329c367d7705be4"
 dependencies = [
  "derive-where",
+ "finito",
  "frame-metadata",
  "futures",
  "hex",
@@ -3810,6 +3821,7 @@ dependencies = [
  "subxt-core",
  "subxt-lightclient",
  "thiserror 2.0.12",
+ "tokio",
  "tokio-util",
  "tracing",
  "url",

--- a/chain-alerter/Cargo.toml
+++ b/chain-alerter/Cargo.toml
@@ -16,7 +16,7 @@ rustls.workspace = true
 scale-value.workspace = true
 serde_json.workspace = true
 subspace-process.workspace = true
-subxt = { workspace = true, features = ["jsonrpsee", "native"] }
+subxt = { workspace = true, features = ["jsonrpsee", "native", "reconnecting-rpc-client"] }
 tokio = { workspace = true, features = ["macros", "parking_lot", "rt-multi-thread", "fs"] }
 tracing.workspace = true
 slack-morphism = { workspace = true, features = ["hyper"] }

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -6,7 +6,7 @@ mod tests;
 use crate::format::{fmt_amount, fmt_duration, fmt_timestamp};
 use crate::subspace::{
     AI3, Balance, BlockInfo, BlockTime, EventInfo, ExtrinsicInfo, SubspaceConfig,
-    gap_since_last_block, gap_since_time,
+    TARGET_BLOCK_INTERVAL, gap_since_last_block, gap_since_time,
 };
 use chrono::Utc;
 use scale_value::Composite;
@@ -28,7 +28,7 @@ const MIN_BALANCE_CHANGE: Balance = 1_000_000 * AI3;
 /// `pallet-timestamp` enforces a `MinimumPeriod` of 3 seconds in Subspace, and a
 /// `MAX_TIMESTAMP_DRIFT_MILLIS` of 30 seconds from each node's local clock.
 /// <https://github.com/paritytech/polkadot-sdk/blob/0034d178fff88a0fd87cf0ec1d8f122ae0011d78/substrate/frame/timestamp/src/lib.rs#L307>
-const MIN_BLOCK_GAP: Duration = Duration::from_secs(60);
+const MIN_BLOCK_GAP: Duration = Duration::from_secs(TARGET_BLOCK_INTERVAL * 10);
 
 /// Whether we are replaying missed blocks, or checking current blocks.
 /// This impacts block stall checks, which can only be spawned on new blocks.

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -58,7 +58,7 @@ const LARGE_TRANSFER_BLOCKS: [(BlockNumber, RawBlockHash, ExtrinsicIndex, Balanc
 /// Check that the startup alert works on the latest block.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_startup_alert() -> anyhow::Result<()> {
-    let (subspace_client, alert_tx, mut alert_rx, _update_task) =
+    let (subspace_client, _, alert_tx, mut alert_rx, _update_task) =
         test_setup(node_rpc_url()).await?;
 
     let (block_info, _, _) = fetch_block_info(&subspace_client, None, None).await?;
@@ -79,7 +79,7 @@ async fn test_startup_alert() -> anyhow::Result<()> {
 /// Check that the sudo call and event alerts work on a known sudo block.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sudo_alerts() -> anyhow::Result<()> {
-    let (subspace_client, alert_tx, mut alert_rx, _update_task) =
+    let (subspace_client, _, alert_tx, mut alert_rx, _update_task) =
         test_setup(node_rpc_url()).await?;
 
     let (block_info, extrinsics, events) =
@@ -135,7 +135,7 @@ async fn test_sudo_alerts() -> anyhow::Result<()> {
 /// Check that the large balance transfer alert works on known transfer blocks.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_large_balance_transfer_alerts() -> anyhow::Result<()> {
-    let (subspace_client, alert_tx, mut alert_rx, _update_task) =
+    let (subspace_client, _, alert_tx, mut alert_rx, _update_task) =
         test_setup(node_rpc_url()).await?;
 
     for (block_number, block_hash, extrinsic_index, transfer_value, slot) in LARGE_TRANSFER_BLOCKS {
@@ -169,7 +169,7 @@ async fn test_large_balance_transfer_alerts() -> anyhow::Result<()> {
 /// Check that the slot time alert is not triggered when the time per slot is below the threshold.
 #[tokio::test(flavor = "multi_thread")]
 async fn no_expected_test_slot_time_alert() -> anyhow::Result<()> {
-    let (_, alert_tx, mut alert_rx, _update_task) = test_setup(node_rpc_url()).await?;
+    let (_, _, alert_tx, mut alert_rx, _) = test_setup(node_rpc_url()).await?;
 
     let first_block = mock_block_info(1000, Slot(100));
     let second_block = mock_block_info(2000, Slot(200));
@@ -200,7 +200,7 @@ async fn no_expected_test_slot_time_alert() -> anyhow::Result<()> {
 /// has elapsed enough time.
 #[tokio::test(flavor = "multi_thread")]
 async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
-    let (_, alert_tx, mut alert_rx, _update_task) = test_setup(node_rpc_url()).await?;
+    let (_, _, alert_tx, mut alert_rx, _) = test_setup(node_rpc_url()).await?;
 
     let first_block = mock_block_info(1000, Slot(100));
     let second_block = mock_block_info(2000, Slot(200));
@@ -247,7 +247,7 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
 /// but has not elapsed enough time.
 #[tokio::test(flavor = "multi_thread")]
 async fn expected_test_slot_time_alert_but_not_yet() -> anyhow::Result<()> {
-    let (_, alert_tx, mut alert_rx, _update_task) = test_setup(node_rpc_url()).await?;
+    let (_, _, alert_tx, mut alert_rx, _) = test_setup(node_rpc_url()).await?;
 
     let first_block = mock_block_info(1000, Slot(100));
     let second_block = mock_block_info(2000, Slot(200));

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -23,6 +23,9 @@ use tracing::{debug, info, trace, warn};
 /// Copied from subspace-runtime-primitives.
 pub const AI3: Balance = 10_u128.pow(18);
 
+/// The target block interval, in seconds.
+pub const TARGET_BLOCK_INTERVAL: u64 = 6;
+
 /// The default RPC URL for a local Subspace node.
 pub const LOCAL_SUBSPACE_NODE_URL: &str = "ws://127.0.0.1:9944";
 


### PR DESCRIPTION
This PR makes the RPC client reconnect after a connection failure.

It also exposes the raw RPC client to other code, so we can make calls that aren't available in `subxt` (for example, block hash by height).

Close #33