### PR TITLE
Ignore typical errors during RPC reconnections

### DIFF
--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -404,7 +404,8 @@ pub async fn check_for_block_stall(
 
     let old_block_info = block_info;
 
-    // Since we exit on panic, there's no need to check the result of the spawned task.
+    // There's no need to check the result of the spawned task, panics are impossible, and other
+    // errors are handled by replaying missed blocks on restart.
     tokio::spawn(async move {
         sleep(MIN_BLOCK_GAP).await;
 
@@ -422,15 +423,15 @@ pub async fn check_for_block_stall(
 
         let gap = gap_since_time(Utc::now(), old_block_info);
 
-        // Send errors are fatal and require a restart.
-        alert_tx
+        // If we have restarted, the new alerter will replay missed blocks, so we can ignore any
+        // send errors to dropped channels. This also avoids panics during process shutdown.
+        let _ = alert_tx
             .send(Alert::new(
                 AlertKind::BlockProductionStall { gap },
                 old_block_info,
                 mode,
             ))
-            .await
-            .expect("sending Slack alert failed");
+            .await;
     });
 }
 

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -378,10 +378,9 @@ pub async fn check_block(
         // No block time to check against.
         warn!(
             ?mode,
-            "Block time unavailable in block:\n\
-            {block_info}\n\
-            Previous block:\n\
-            {prev_block_info}"
+            ?block_info,
+            ?prev_block_info,
+            "Block time unavailable in block",
         );
     };
 
@@ -533,8 +532,8 @@ where
             // TODO: check transfer_all by accessing account storage to get the value
             warn!(
                 ?mode,
-                "Balance: extrinsic amount unavailable in block:\n\
-                {extrinsic_info}",
+                ?extrinsic_info,
+                "Balance: extrinsic amount unavailable in block",
             );
         }
     }

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -82,10 +82,16 @@ async fn setup(
     // aws-lc, but there can only be one per process. We use the library with more formal
     // verification.
     //
+    // We expect errors here during reconnections, so we log and ignore them.
+    //
     // TODO: remove ring to reduce compile time/size
-    rustls::crypto::aws_lc_rs::default_provider()
+    let _ = rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .map_err(|_| anyhow::anyhow!("Selecting default TLS crypto provider failed"))?;
+        .inspect_err(|_| {
+            warn!(
+                "Selecting default TLS crypto provider failed, this is expected during reconnections"
+            )
+        });
 
     // Connect to Slack and get basic info.
     let slack_client_info = SlackClientInfo::new(

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -175,10 +175,7 @@ async fn run() -> anyhow::Result<()> {
             .is_multiple_of(BLOCK_UPDATE_LOGGING_INTERVAL)
         {
             // Let the user know we're still alive
-            info!(
-                "Processed block:\n\
-                {block_info}"
-            );
+            info!(?block_info, "Processed block");
         }
 
         // Notify spawned tasks that a new block has arrived, and give them time to process that
@@ -250,8 +247,7 @@ pub async fn replay_previous_blocks(
     let (gap_start, gap_end) = if block_info.block_height <= prev_block_info.block_height {
         // Multiple blocks at the same height, a chain fork.
         info!(
-            "chain fork detected: {} ({}) -> {} ({})\n\
-            checking skipped blocks",
+            "chain fork detected: {} ({}) -> {} ({}), checking skipped blocks",
             prev_block_info.block_height,
             prev_block_info.block_hash,
             block_info.block_height,
@@ -268,8 +264,7 @@ pub async fn replay_previous_blocks(
     } else {
         // A gap in the chain of blocks.
         warn!(
-            "{} block gap detected: {} ({}) -> {} ({})\n\
-            checking skipped blocks",
+            "{} block gap detected: {} ({}) -> {} ({}), checking skipped blocks",
             block_info.block_height - prev_block_info.block_height - 1,
             prev_block_info.block_height,
             prev_block_info.block_hash,
@@ -334,10 +329,7 @@ pub async fn replay_previous_blocks(
                 .is_multiple_of(BLOCK_UPDATE_LOGGING_INTERVAL)
             {
                 // Let the user know we're still alive
-                info!(
-                    "Replayed missed block:\n\
-                    {block_info}"
-                );
+                info!(?block_info, "Replayed missed block");
             }
 
             run_on_block(

--- a/chain-alerter/src/slack.rs
+++ b/chain-alerter/src/slack.rs
@@ -299,9 +299,9 @@ impl SlackClientInfo {
         let slack_session = self.open_session();
 
         info!(
-            "posting message to '{TEST_CHANNEL_NAME}' channel id: {:?}...\n\
-            {alert:?}",
-            self.channel_id,
+            ?alert,
+            channel_id =?self.channel_id,
+            "posting message to '{TEST_CHANNEL_NAME}'",
         );
 
         let Alert {

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -321,8 +321,8 @@ impl ExtrinsicInfo {
             // If we can't get the extrinsic pallet and call name, there's nothing we can do.
             // Just log it and move on.
             warn!(
-                "extrinsic {} pallet/name unavailable in block:\n\
-                {block_info}",
+                ?block_info,
+                "extrinsic {} pallet/name unavailable in block",
                 extrinsic.index(),
             );
             return None;
@@ -332,13 +332,12 @@ impl ExtrinsicInfo {
         // extrinsic alerts. So we just warn and substitute empty fields.
         let fields = extrinsic.field_values().unwrap_or_else(|_| {
             warn!(
-                "extrinsic {}:{} ({}) fields unavailable in block:\n\
-                Hash: {:?}\n\
-                {block_info}",
+                ?block_info,
+                hash = ?extrinsic.hash(),
+                "extrinsic {}:{} ({}) fields unavailable in block",
                 meta.pallet.name(),
                 meta.variant.name,
                 extrinsic.index(),
-                extrinsic.hash(),
             );
             Composite::unnamed(Vec::new())
         });
@@ -404,8 +403,8 @@ impl EventInfo {
         // event alerts. So we just warn and substitute empty fields.
         let fields = event.field_values().unwrap_or_else(|_| {
             warn!(
-                "event {}:{} ({}) fields unavailable in block:\n\
-                {block_info}",
+                ?block_info,
+                "event {}:{} ({}) fields unavailable in block",
                 meta.pallet.name(),
                 meta.variant.name,
                 event.index(),


### PR DESCRIPTION
We return errors to `main()`, or panic on them. But some errors are expected during an alerter restart, and need to be ignored.