### PR TITLE
Cleanups & fixes for farming monitor

### DIFF
--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -5,7 +5,7 @@ mod tests;
 
 use crate::format::{fmt_amount, fmt_duration, fmt_timestamp};
 use crate::subspace::{
-    AI3, Balance, BlockInfo, BlockTime, EventInfo, ExtrinsicInfo, SubspaceConfig,
+    AI3, Balance, BlockInfo, BlockTime, Event, EventInfo, ExtrinsicInfo, SubspaceConfig,
     TARGET_BLOCK_INTERVAL, gap_since_last_block, gap_since_time,
 };
 use chrono::Utc;
@@ -14,7 +14,6 @@ use std::fmt::{self, Display};
 use std::time::Duration;
 use subxt::blocks::ExtrinsicDetails;
 use subxt::client::OnlineClientT;
-use subxt::events::EventDetails;
 use tokio::sync::{mpsc, watch};
 use tokio::time::sleep;
 use tracing::{debug, warn};
@@ -608,7 +607,7 @@ pub async fn check_event(
     // TODO: when we add a check that doesn't work on replayed blocks, skip it using mode
     mode: BlockCheckMode,
     alert_tx: &mpsc::Sender<Alert>,
-    event: &EventDetails<SubspaceConfig>,
+    event: &Event,
     block_info: &BlockInfo,
 ) -> anyhow::Result<()> {
     let event_info = EventInfo::new(event, block_info);

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -150,7 +150,7 @@ pub enum AlertKind {
     /// Farmers count has decreased suddenly.
     FarmersDecreasedSuddenly {
         /// The number of farmers with votes.
-        number_of_farmers_with_votes: u32,
+        number_of_farmers_with_votes: usize,
 
         /// The average number of farmers with votes.
         average_number_of_farmers_with_votes: f64,
@@ -162,7 +162,7 @@ pub enum AlertKind {
     /// Farmers count has increased suddenly.
     FarmersIncreasedSuddenly {
         /// The number of farmers with votes.
-        number_of_farmers_with_votes: u32,
+        number_of_farmers_with_votes: usize,
 
         /// The average number of farmers with votes.
         average_number_of_farmers_with_votes: f64,

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -184,7 +184,7 @@ impl Display for AlertKind {
                 write!(
                     f,
                     "**Block production stalled**\n\
-                    Gap: {}",
+                    Time since last block: {}",
                     fmt_duration(*gap),
                 )
             }

--- a/chain-alerter/src/farming_monitor.rs
+++ b/chain-alerter/src/farming_monitor.rs
@@ -159,10 +159,10 @@ impl MemoryFarmingMonitor {
         let farmers_going_inactive =
             last_block_voted_by_farmer
                 .iter()
-                .filter(|(_, last_voted_block)| {
-                    let last_block_voted =
+                .filter(|(_, last_block_voted)| {
+                    let active_block_threshold =
                         block_height.saturating_sub(config.clone().inactive_block_threshold);
-                    last_voted_block.lt(&&last_block_voted)
+                    **last_block_voted < active_block_threshold
                 });
 
         // Remove the farmers that have not voted in the last `inactive_block_threshold` blocks.

--- a/chain-alerter/src/subspace.rs
+++ b/chain-alerter/src/subspace.rs
@@ -81,6 +81,9 @@ pub type ExtrinsicIndex = u32;
 /// The Subspace/subxt event index type.
 pub type EventIndex = u32;
 
+/// The Subspace/subxt event details type.
+pub type Event = EventDetails<SubspaceConfig>;
+
 /// Create a new reconnecting Subspace client.
 pub async fn create_subspace_client(
     node_url: impl AsRef<str>,

--- a/chain-alerter/src/subspace/tests.rs
+++ b/chain-alerter/src/subspace/tests.rs
@@ -3,14 +3,14 @@
 use crate::ALERT_BUFFER_SIZE;
 use crate::alerts::Alert;
 use crate::subspace::{
-    BlockInfo, BlockNumber, EventIndex, EventInfo, ExtrinsicIndex, ExtrinsicInfo,
+    BlockInfo, BlockNumber, Event, EventIndex, EventInfo, ExtrinsicIndex, ExtrinsicInfo,
     FOUNDATION_SUBSPACE_NODE_URL, RawRpcClient, SubspaceClient, SubspaceConfig,
     create_subspace_client, spawn_metadata_update_task,
 };
 use std::env;
 use subspace_process::{AsyncJoinOnDrop, init_logger};
 use subxt::blocks::{ExtrinsicDetails, Extrinsics};
-use subxt::events::{EventDetails, Events};
+use subxt::events::Events;
 use subxt::utils::H256;
 use tokio::sync::mpsc;
 use tracing::info;
@@ -128,7 +128,7 @@ pub async fn decode_event(
     block_info: &BlockInfo,
     events: &Events<SubspaceConfig>,
     event_index: EventIndex,
-) -> anyhow::Result<(EventDetails<SubspaceConfig>, EventInfo)> {
+) -> anyhow::Result<(Event, EventInfo)> {
     // TODO: extract this into a subspace test helper function
     let event = events
         .iter()


### PR DESCRIPTION
This PR covers my remaining comments from PR #32:
- parse events once
- do farmer alerts once we have 100 blocks in our records
- allow the alert threshold to be changed at runtime
- remove unnecessary clones (x2)
- remove most conversions by using usize for lengths/counts

And also:
- pass references because they're more efficient
- fixes the stall alert label, it's not a block gap
