### PR TITLE
Avoid farming monitor spamming alerts every block

### DIFF
--- a/chain-alerter/src/farming_monitor.rs
+++ b/chain-alerter/src/farming_monitor.rs
@@ -64,13 +64,14 @@ pub struct FarmingMonitorConfig {
     pub minimum_block_interval: usize,
 }
 
+/// The type of alert issued by the farming monitor, if there was one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FarmingMonitorStatus {
-    /// The farming monitor has emitted an alert
+    /// The farming monitor has emitted an increase alert.
     AlertingIncrease,
-    /// The farming monitor has emitted an alert
+    /// The farming monitor has emitted a decrease alert.
     AlertingDecrease,
-    /// The farming monitor has not emitted an alert
+    /// The farming monitor did not emit an alert.
     NotAlerting,
 }
 
@@ -89,7 +90,7 @@ pub struct FarmingMonitorState {
     /// The number of farmers that have votes in the last `max_block_interval` blocks.
     /// TODO: delete the last few entries when a reorg happens.
     active_farmers_in_last_blocks: VecDeque<usize>,
-    /// Status of the alert.
+    /// The last alert issued by the farming monitor.
     status: FarmingMonitorStatus,
 }
 


### PR DESCRIPTION
## Problem

Once we detected a sudden increase or decrease in the number of active farmers, we were emitting an alert every block that met the alerting threshold.

## Solution

Created `FarmingMonitorStatus` that tracks the alerting state (`AlertingIncrease`, `AlertingDecrease`, `NotAlerting`) and added to `FarmingMonitor` state attribute. Once an alert is emitted the following are ignored, it takes the alert to be resolved (back to the sanity range) to be able to be triggered again.

## Additional

Little refactor for using const instead of "magic" strings and filtering the events by `palletName=Subspace` and `eventName=FarmerVote`. This last change didn't have any effect since there is no other event with the field name `public_key` though this is a more robust way to filter in votes 