### PR TITLE
Avoid test hangs by removing 

### DIFF
--- a/chain-alerter/src/subspace/tests.rs
+++ b/chain-alerter/src/subspace/tests.rs
@@ -49,7 +49,7 @@ pub async fn test_setup(
         create_subspace_client(node_rpc_url.as_ref()).await?;
 
     // Create a channel to receive alerts.
-    let (alert_tx, alert_rx) = mpsc::channel(ALERT_BUFFER_SIZE);
+    let (alert_tx, alert_rx) = alert_channel_only_setup();
 
     Ok((
         chain_client,
@@ -58,6 +58,12 @@ pub async fn test_setup(
         alert_rx,
         update_task,
     ))
+}
+
+/// Set up alert channels for testing.
+pub fn alert_channel_only_setup() -> (mpsc::Sender<Alert>, mpsc::Receiver<Alert>) {
+    let (alert_tx, alert_rx) = mpsc::channel(ALERT_BUFFER_SIZE);
+    (alert_tx, alert_rx)
 }
 
 /// Get the block info, extrinsics, and events for a block.


### PR DESCRIPTION
Some of our tests use entirely mocked test data, without connecting to any subspace node.

Very rarely, a test will hang, and CI will timeout and fail:
https://github.com/autonomys/subspace-chain-alerts/actions/runs/17973082992/job/51120146299?pr=47#step:4:733

The first step in diagnosing this bug is removing unnecessary code from those tests.

This also speeds up test runs, and reduces the load our tests cause to public RPC servers.