### PR TITLE
Reduce check interval to 10 minutes for slot time monitor

### DIFF
--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -17,7 +17,7 @@ use tracing::{debug, info, warn};
 pub const DEFAULT_SLOT_TIME_ALERT_THRESHOLD: f64 = 1.05;
 
 /// The default check interval for the slot time monitor.
-pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(3600);
+pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(600);
 
 /// Interface for slot time monitors that consume blocks and perform checks.
 pub trait SlotTimeMonitor {


### PR DESCRIPTION
We're observing an unexpectedly small number of slots when a block stalls, and we'd like to find out if that's because slot production has stalled as well.