### PR TITLE
Improve slot monitoring

### DIFF
--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -557,7 +557,7 @@ impl Display for AlertKind {
             } => {
                 write!(
                     f,
-                    "**Slot per time ratio alert**\n\
+                    "**Slow slot time alert**\n\
                     Current ratio: {current_ratio:.2} slots per second\n\
                     Threshold: {threshold:.2} slots per second\n\
                     Interval: {}",

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -316,6 +316,9 @@ pub enum AlertKind {
 
     /// Slot timing is slower than expected.
     SlowSlotTime {
+        /// The amount of slots.
+        slot_amount: u64,
+
         /// The current ratio of slots to time.
         current_ratio: f64,
 
@@ -328,6 +331,9 @@ pub enum AlertKind {
 
     /// Slot timing is faster than expected.
     FastSlotTime {
+        /// The amount of slots.
+        slot_amount: u64,
+
         /// The current ratio of slots to time.
         current_ratio: f64,
 
@@ -551,6 +557,7 @@ impl Display for AlertKind {
             }
 
             Self::SlowSlotTime {
+                slot_amount,
                 current_ratio,
                 threshold,
                 interval,
@@ -560,12 +567,14 @@ impl Display for AlertKind {
                     "**Slow slot time alert**\n\
                     Current ratio: {current_ratio:.2} slots per second\n\
                     Threshold: {threshold:.2} slots per second\n\
+                    Slot amount: {slot_amount}\n\
                     Interval: {}",
                     fmt_duration(*interval),
                 )
             }
 
             Self::FastSlotTime {
+                slot_amount,
                 current_ratio,
                 threshold,
                 interval,
@@ -575,6 +584,7 @@ impl Display for AlertKind {
                     "**Fast slot time alert**\n\
                     Current ratio: {current_ratio:.2} slots per second\n\
                     Threshold: {threshold:.2} slots per second\n\
+                    Slot amount: {slot_amount}\n\
                     Interval: {}",
                     fmt_duration(*interval),
                 )

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -579,17 +579,18 @@ async fn test_important_address_only_alerts() -> anyhow::Result<()> {
 async fn no_expected_test_slot_time_alert() -> anyhow::Result<()> {
     let (alert_tx, mut alert_rx) = alert_channel_only_setup();
 
-    let first_block = mock_block_info(1000, Slot(100));
-    let second_block = mock_block_info(2000, Slot(200));
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(200000, Slot(200));
 
-    let mut naive_slot_time_monitor = MemorySlotTimeMonitor::new({
-        SlotTimeMonitorConfig {
-            check_interval: Duration::from_secs(1),
-            alert_threshold: 10.0f64,
-            alert_tx: alert_tx.clone(),
-        }
-    });
+    let mut naive_slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        2,       // max_block_buffer - small buffer for testing
+        10.0f64, // slow_slots_threshold
+        0.5f64,  // fast_slots_threshold
+        alert_tx.clone(),
+    ));
 
+    // Process blocks to fill the buffer
     naive_slot_time_monitor
         .process_block(BlockCheckMode::Replay, &first_block)
         .await?;
@@ -610,17 +611,18 @@ async fn no_expected_test_slot_time_alert() -> anyhow::Result<()> {
 async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
     let (alert_tx, mut alert_rx) = alert_channel_only_setup();
 
-    let first_block = mock_block_info(1000, Slot(100));
-    let second_block = mock_block_info(2000, Slot(200));
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(200000, Slot(200));
 
-    let mut strict_slot_time_monitor = MemorySlotTimeMonitor::new({
-        SlotTimeMonitorConfig {
-            check_interval: Duration::from_secs(1),
-            alert_threshold: 0f64,
-            alert_tx: alert_tx.clone(),
-        }
-    });
+    let mut strict_slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        2,      // max_block_buffer - small buffer for testing
+        0f64,   // slow_slots_threshold
+        0.5f64, // fast_slots_threshold
+        alert_tx.clone(),
+    ));
 
+    // Process blocks to fill the buffer
     strict_slot_time_monitor
         .process_block(BlockCheckMode::Replay, &first_block)
         .await?;
@@ -635,13 +637,10 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
     assert_eq!(
         alert,
         Alert::new(
-            AlertKind::SlotTime {
-                current_ratio: 0.01,
+            AlertKind::SlowSlotTime {
+                current_ratio: 1.0,
                 threshold: 0.0,
                 interval: Duration::from_secs(1),
-                first_slot_time: first_block
-                    .time
-                    .expect("block must have time to trigger alert"),
             },
             second_block,
             BlockCheckMode::Replay,
@@ -661,17 +660,18 @@ async fn expected_test_slot_time_alert() -> anyhow::Result<()> {
 async fn expected_test_slot_time_alert_but_not_yet() -> anyhow::Result<()> {
     let (alert_tx, mut alert_rx) = alert_channel_only_setup();
 
-    let first_block = mock_block_info(1000, Slot(100));
-    let second_block = mock_block_info(2000, Slot(200));
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(200000, Slot(200));
 
-    let mut strict_slot_time_monitor = MemorySlotTimeMonitor::new({
-        SlotTimeMonitorConfig {
-            check_interval: Duration::from_secs(3600 * 24),
-            alert_threshold: 0f64,
-            alert_tx: alert_tx.clone(),
-        }
-    });
+    let mut strict_slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(3600 * 24),
+        2,      // max_block_buffer - small buffer for testing
+        2.0f64, // slow_slots_threshold (1.0 < 2.0, so won't trigger)
+        0.5f64, // fast_slots_threshold
+        alert_tx.clone(),
+    ));
 
+    // Process blocks to fill the buffer
     strict_slot_time_monitor
         .process_block(BlockCheckMode::Replay, &first_block)
         .await?;
@@ -682,6 +682,178 @@ async fn expected_test_slot_time_alert_but_not_yet() -> anyhow::Result<()> {
     alert_rx
         .try_recv()
         .expect_err("alert received when none expected");
+
+    Ok(())
+}
+
+/// Check that the slot time alert is triggered 
+/// when the slot per time ratio gets above the slow threshold.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_slot_time_above_slow_threshold() -> anyhow::Result<()> {
+    let (alert_tx, mut alert_rx) = alert_channel_only_setup();
+
+    // Create blocks with a very fast slot progression (high ratio)
+    // First block at time 100000ms, slot 100
+    // Second block at time 101000ms, slot 200
+    // This gives us 100 slots in 1000ms = 100 slots per second
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(101000, Slot(200));
+
+    let mut slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        2,      // max_block_buffer - small buffer for testing
+        0.5f64, // slow_slots_threshold (1.0 > 0.5, so should trigger)
+        0.1f64, // fast_slots_threshold
+        alert_tx.clone(),
+    ));
+
+    // Process blocks to fill the buffer
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &first_block)
+        .await?;
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &second_block)
+        .await?;
+
+    let alert = alert_rx
+        .try_recv()
+        .expect("SlowSlotTime alert not received when expected");
+
+    assert_eq!(
+        alert,
+        Alert::new(
+            AlertKind::SlowSlotTime {
+                current_ratio: 100.0, // 100 slots / 1000ms = 100 slots per second
+                threshold: 0.5,
+                interval: Duration::from_secs(1),
+            },
+            second_block,
+            BlockCheckMode::Replay,
+        )
+    );
+
+    alert_rx
+        .try_recv()
+        .expect_err("alert received when none expected");
+
+    Ok(())
+}
+
+/// Check that the slot time alert is triggered when the slot per time ratio gets below the fast
+/// threshold.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_slot_time_below_fast_threshold() -> anyhow::Result<()> {
+    let (alert_tx, mut alert_rx) = alert_channel_only_setup();
+
+    // Create blocks with a very slow slot progression (low ratio)
+    // First block at time 100000, slot 100
+    // Second block at time 200000, slot 200
+    // This gives us 100 slots in 100000ms = 0.1 slots per second
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(200000, Slot(200));
+
+    let mut slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        2,      // max_block_buffer - small buffer for testing
+        2.0f64, // slow_slots_threshold (1.0 < 2.0, so won't trigger slow alert)
+        1.5f64, // fast_slots_threshold (1.0 < 1.5, so will trigger fast alert)
+        alert_tx.clone(),
+    ));
+
+    // Process blocks to fill the buffer
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &first_block)
+        .await?;
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &second_block)
+        .await?;
+
+    let alert = alert_rx
+        .try_recv()
+        .expect("FastSlotTime alert not received when expected");
+
+    assert_eq!(
+        alert,
+        Alert::new(
+            AlertKind::FastSlotTime {
+                current_ratio: 1.0, // 100 slots / 100000ms = 1.0 slots per second
+                threshold: 1.5,
+                interval: Duration::from_secs(1),
+            },
+            second_block,
+            BlockCheckMode::Replay,
+        )
+    );
+
+    alert_rx
+        .try_recv()
+        .expect_err("alert received when none expected");
+
+    Ok(())
+}
+
+/// Check that slot time alerts are ignored during startup mode.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_slot_time_alerts_ignored_during_startup() -> anyhow::Result<()> {
+    let (alert_tx, mut alert_rx) = alert_channel_only_setup();
+
+    // Create blocks that would normally trigger an alert
+    let first_block = mock_block_info(1000, Slot(100));
+    let second_block = mock_block_info(2000, Slot(200));
+
+    let mut slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        2,      // max_block_buffer - small buffer for testing
+        0.5f64, // slow_slots_threshold (0.1 < 0.5, so would normally trigger)
+        0.1f64, // fast_slots_threshold
+        alert_tx.clone(),
+    ));
+
+    // Process blocks in Startup mode - should not trigger alerts
+    slot_time_monitor
+        .process_block(BlockCheckMode::Startup, &first_block)
+        .await?;
+    slot_time_monitor
+        .process_block(BlockCheckMode::Startup, &second_block)
+        .await?;
+
+    // No alerts should be received during startup
+    alert_rx
+        .try_recv()
+        .expect_err("alert received during startup when none expected");
+
+    Ok(())
+}
+
+/// Check that slot time alerts are not triggered when the buffer is not full.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_slot_time_alerts_not_triggered_when_buffer_not_full() -> anyhow::Result<()> {
+    let (alert_tx, mut alert_rx) = alert_channel_only_setup();
+
+    // Create blocks that would normally trigger an alert
+    let first_block = mock_block_info(100000, Slot(100));
+    let second_block = mock_block_info(200000, Slot(200));
+
+    let mut slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
+        Duration::from_secs(1),
+        3,      // max_block_buffer - need 3 blocks to fill buffer
+        0.5f64, // slow_slots_threshold (1.0 > 0.5, so would trigger if buffer was full)
+        0.1f64, // fast_slots_threshold
+        alert_tx.clone(),
+    ));
+
+    // Process only 2 blocks - buffer not full, so no alerts should be triggered
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &first_block)
+        .await?;
+    slot_time_monitor
+        .process_block(BlockCheckMode::Replay, &second_block)
+        .await?;
+
+    // No alerts should be received when buffer is not full
+    alert_rx
+        .try_recv()
+        .expect_err("alert received when buffer not full");
 
     Ok(())
 }

--- a/chain-alerter/src/alerts/tests.rs
+++ b/chain-alerter/src/alerts/tests.rs
@@ -686,7 +686,7 @@ async fn expected_test_slot_time_alert_but_not_yet() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check that the slot time alert is triggered 
+/// Check that the slot time alert is triggered
 /// when the slot per time ratio gets above the slow threshold.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_slot_time_above_slow_threshold() -> anyhow::Result<()> {

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -25,7 +25,8 @@ use crate::farming_monitor::{
 };
 use crate::slack::{SLACK_OAUTH_SECRET_PATH, SlackClientInfo};
 use crate::slot_time_monitor::{
-    DEFAULT_CHECK_INTERVAL, DEFAULT_SLOT_TIME_ALERT_THRESHOLD, SlotTimeMonitorConfig,
+    DEFAULT_CHECK_INTERVAL, DEFAULT_FAST_SLOTS_THRESHOLD, DEFAULT_MAX_BLOCK_BUFFER,
+    DEFAULT_SLOW_SLOTS_THRESHOLD, SlotTimeMonitorConfig,
 };
 use crate::subspace::{
     BlockHash, BlockInfo, BlockLink, BlockNumber, LOCAL_SUBSPACE_NODE_URL,
@@ -473,7 +474,9 @@ async fn check_best_blocks(
     // Slot time monitor is used to check if the slot time is within the expected range.
     let mut slot_time_monitor = MemorySlotTimeMonitor::new(SlotTimeMonitorConfig::new(
         DEFAULT_CHECK_INTERVAL,
-        DEFAULT_SLOT_TIME_ALERT_THRESHOLD,
+        DEFAULT_MAX_BLOCK_BUFFER,
+        DEFAULT_SLOW_SLOTS_THRESHOLD,
+        DEFAULT_FAST_SLOTS_THRESHOLD,
         alert_tx.clone(),
     ));
 

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -7,14 +7,21 @@
 pub mod test_utils;
 
 use crate::alerts::{Alert, AlertKind, BlockCheckMode};
-use crate::subspace::{BlockInfo, BlockTime, RawTime, Slot};
+use crate::subspace::BlockInfo;
+use anyhow::Ok;
+use std::collections::VecDeque;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
-use tracing::{debug, info, warn};
 
 /// The default threshold for the slot time alert.
-pub const DEFAULT_SLOT_TIME_ALERT_THRESHOLD: f64 = 1.05;
+pub const DEFAULT_SLOW_SLOTS_THRESHOLD: f64 = 1.05;
+
+/// The default fast slots threshold for the slot time alert.
+pub const DEFAULT_FAST_SLOTS_THRESHOLD: f64 = 0.95;
+
+/// The default maximum block buffer size.
+pub const DEFAULT_MAX_BLOCK_BUFFER: usize = 100;
 
 /// The default check interval for the slot time monitor.
 pub const DEFAULT_CHECK_INTERVAL: Duration = Duration::from_secs(600);
@@ -34,9 +41,12 @@ pub trait SlotTimeMonitor {
 pub struct SlotTimeMonitorConfig {
     /// Interval between checks of slot timing.
     pub check_interval: Duration,
+    /// Maximum block buffer
+    pub max_block_buffer: usize,
     /// Minimum threshold for alerting based on time-per-slot ratio.
-    /// TODO: also alert on a maximum threshold
-    pub alert_threshold: f64,
+    pub slow_slots_threshold: f64,
+    /// Maximum threshold for alerting based on time-per-slot ratio.
+    pub fast_slots_threshold: f64,
     /// Channel used to emit alerts.
     pub alert_tx: mpsc::Sender<Alert>,
 }
@@ -55,21 +65,19 @@ pub struct MemorySlotTimeMonitor {
 /// Reorgs are effectively ignored in the slot time state.
 /// If the chain passes `next_check_time` before the reorg, then the reorg will be a long way
 /// behind the new `next_check_time`.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SlotTimeMonitorState {
-    /// First slot observed in the current checking interval.
-    first_slot_in_interval: Slot,
-    /// Consensus wall-clock time when the first slot of the interval was observed.
-    first_slot_time: BlockTime,
-    /// Next consensus wall-clock time when a check should occur.
-    next_check_time: BlockTime,
+    /// Block buffer
+    block_buffer: VecDeque<BlockInfo>,
 }
 
 impl SlotTimeMonitorConfig {
     /// Create a new slot time monitor configuration with the provided parameters.
     pub fn new(
         check_interval: Duration,
-        alert_threshold: f64,
+        max_block_buffer: usize,
+        slow_slots_threshold: f64,
+        fast_slots_threshold: f64,
         alert_tx: mpsc::Sender<Alert>,
     ) -> Self {
         assert!(
@@ -79,7 +87,9 @@ impl SlotTimeMonitorConfig {
 
         Self {
             check_interval,
-            alert_threshold,
+            max_block_buffer,
+            slow_slots_threshold,
+            fast_slots_threshold,
             alert_tx,
         }
     }
@@ -92,83 +102,9 @@ impl SlotTimeMonitor for MemorySlotTimeMonitor {
         mode: BlockCheckMode,
         block_info: &BlockInfo,
     ) -> anyhow::Result<()> {
-        let (block_time, block_slot) = match (block_info.time, block_info.slot) {
-            (Some(block_time), Some(block_slot)) => (block_time, block_slot),
-            // These errors indicate a chain metadata issue, which should be fixed by restarting.
-            (None, None) => {
-                warn!(?mode, "Block time and slot not found");
-                return Err(anyhow::anyhow!("block time and slot not found"));
-            }
-            (None, Some(_)) => {
-                warn!(?mode, "Block time not found");
-                return Err(anyhow::anyhow!("block time not found"));
-            }
-            (Some(_), None) => {
-                warn!(?mode, "Block slot not found");
-                return Err(anyhow::anyhow!("block slot not found"));
-            }
-        };
+        self.push_block_to_buffer(*block_info);
 
-        debug!(
-            ?mode,
-            "Extracted slot: {:?} for block {:?}",
-            block_slot,
-            block_info.height(),
-        );
-
-        match self.state {
-            // slot available, we should check if we are in the interval
-            Some(state) if state.next_check_time <= block_time && !mode.is_startup() => {
-                debug!(?mode, "Checking slot time alert in interval...");
-
-                let slot_diff = block_slot - state.first_slot_in_interval;
-                let time_diff = state
-                    .next_check_time
-                    .unix_time
-                    .checked_sub(state.first_slot_time.unix_time);
-
-                if let Some(time_diff) = time_diff {
-                    let time_diff_in_seconds = time_diff / 1000;
-                    #[allow(
-                        clippy::cast_precision_loss,
-                        reason = "time and slot differences are much smaller than 52 bits in practice"
-                    )]
-                    let time_per_slot = time_diff_in_seconds as f64 / slot_diff as f64;
-                    if time_per_slot > self.config.alert_threshold {
-                        info!(
-                            ?mode,
-                            "Time per slot alert triggered, time_per_slot: {time_per_slot}",
-                        );
-                        self.send_alert(time_per_slot, *block_info, mode).await?;
-                    } else {
-                        debug!(
-                            ?mode,
-                            "Time per slot not triggered, time_per_slot: {time_per_slot}",
-                        );
-                    }
-                    self.schedule_next_check(block_time, block_slot);
-
-                    Ok(())
-                } else {
-                    warn!(
-                        ?mode,
-                        "Unexpected slot time, earlier than first block in interval: {block_info:?} - {state:?}",
-                    );
-                    // This error indicates a chain gap or history consistency issue, or a metadata
-                    // issue, which should be fixed by restarting.
-                    Err(anyhow::anyhow!(
-                        "Unexpected slot time, earlier than first block in interval: {block_info:?} - {state:?}"
-                    ))
-                }
-            }
-            // do nothing if we are in the interval, or during startup
-            Some(_) => Ok(()),
-            // we received a new block, so we init the first check
-            None => {
-                self.schedule_next_check(block_time, block_slot);
-                Ok(())
-            }
-        }
+        self.check_slot_time(mode, block_info).await
     }
 }
 
@@ -181,8 +117,97 @@ impl MemorySlotTimeMonitor {
         }
     }
 
+    /// Push a block to the buffer and remove the oldest block if the buffer is full.
+    fn push_block_to_buffer(&mut self, block_info: BlockInfo) {
+        // Initialize state if it doesn't exist
+        if self.state.is_none() {
+            self.state = Some(SlotTimeMonitorState {
+                block_buffer: VecDeque::new(),
+            });
+        }
+
+        if let Some(state) = self.state.as_mut() {
+            state.block_buffer.push_front(block_info);
+            if state.block_buffer.len() > self.config.max_block_buffer {
+                state.block_buffer.pop_back();
+            }
+        }
+    }
+
+    /// Check the slot time and send alerts if needed.
+    #[cfg_attr(
+        not(test),
+        allow(
+            clippy::cast_precision_loss,
+            reason = "Casting numbers are within a safe range"
+        )
+    )]
+    async fn check_slot_time(
+        &mut self,
+        mode: BlockCheckMode,
+        block_info: &BlockInfo,
+    ) -> anyhow::Result<()> {
+        // Ignore alerts during startup mode
+        if mode.is_startup() {
+            return Ok(());
+        }
+
+        // Only check slot timing when the buffer is full
+        let state = match &self.state {
+            Some(state) => state,
+            None => return Ok(()),
+        };
+
+        // Check if buffer is full (has reached max_block_buffer)
+        if state.block_buffer.len() < self.config.max_block_buffer {
+            return Ok(());
+        }
+
+        let (lowest_block, last_block) = (
+            state.block_buffer.back().cloned(),
+            state.block_buffer.front().cloned(),
+        );
+
+        let (lowest_block, last_block) = match (lowest_block, last_block) {
+            (Some(lowest_block), Some(last_block)) => (lowest_block, last_block),
+            _ => return Ok(()),
+        };
+
+        let (lowest_block_slot, last_block_slot) = match (lowest_block.slot, last_block.slot) {
+            (Some(lowest_block_slot), Some(last_block_slot)) => {
+                (lowest_block_slot, last_block_slot)
+            }
+            // If either block doesn't have a slot, return Ok(())
+            _ => return Ok(()),
+        };
+
+        let (lowest_block_time_in_seconds, last_block_time_in_seconds) =
+            match (lowest_block.time, last_block.time) {
+                (Some(lowest_block_time), Some(last_block_time)) => (
+                    lowest_block_time.unix_time / 1000,
+                    last_block_time.unix_time / 1000,
+                ),
+                // If either block doesn't have a time, return Ok(())
+                _ => return Ok(()),
+            };
+
+        let slot_diff = last_block_slot - lowest_block_slot;
+        let time_diff = last_block_time_in_seconds - lowest_block_time_in_seconds;
+        let slot_diff_per_time_diff = slot_diff as f64 / time_diff as f64;
+
+        if slot_diff_per_time_diff > self.config.slow_slots_threshold {
+            self.send_slow_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
+                .await?;
+        } else if slot_diff_per_time_diff < self.config.fast_slots_threshold {
+            self.send_fast_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
+                .await?;
+        }
+
+        Ok(())
+    }
+
     /// Send a slot time alert with the computed ratio and block info.
-    async fn send_alert(
+    async fn send_slow_slot_time_alert(
         &self,
         slot_diff_per_time_diff: f64,
         block_info: BlockInfo,
@@ -191,14 +216,10 @@ impl MemorySlotTimeMonitor {
         self.config
             .alert_tx
             .send(Alert::new(
-                AlertKind::SlotTime {
+                AlertKind::SlowSlotTime {
                     current_ratio: slot_diff_per_time_diff,
-                    threshold: self.config.alert_threshold,
+                    threshold: self.config.slow_slots_threshold,
                     interval: self.config.check_interval,
-                    first_slot_time: self
-                        .state
-                        .expect("alerts are only triggered when state is present")
-                        .first_slot_time,
                 },
                 block_info,
                 mode,
@@ -206,21 +227,24 @@ impl MemorySlotTimeMonitor {
             .await
     }
 
-    /// Schedule the next check at `current_time + check_interval` and record the slot.
-    fn schedule_next_check(&mut self, current_time: BlockTime, current_slot: Slot) {
-        let next_check_time = BlockTime {
-            unix_time: current_time.unix_time
-                + RawTime::try_from(self.config.check_interval.as_millis())
-                    .expect("already checked when constructing config"),
-        };
-        debug!(
-            "Scheduling next check for block time: {:?}",
-            next_check_time
-        );
-        self.state = Some(SlotTimeMonitorState {
-            first_slot_in_interval: current_slot,
-            first_slot_time: current_time,
-            next_check_time,
-        });
+    /// Send a fast slot time alert with the computed ratio and block info.
+    async fn send_fast_slot_time_alert(
+        &self,
+        slot_diff_per_time_diff: f64,
+        block_info: BlockInfo,
+        mode: BlockCheckMode,
+    ) -> Result<(), SendError<Alert>> {
+        self.config
+            .alert_tx
+            .send(Alert::new(
+                AlertKind::FastSlotTime {
+                    current_ratio: slot_diff_per_time_diff,
+                    threshold: self.config.fast_slots_threshold,
+                    interval: self.config.check_interval,
+                },
+                block_info,
+                mode,
+            ))
+            .await
     }
 }

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -220,10 +220,7 @@ impl MemorySlotTimeMonitor {
             self.send_fast_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
                 .await?;
         } else {
-            // Reset alerting status when slot timing is within normal ranges
-            if let Some(state) = self.state.as_mut() {
-                state.alerting_status = AlertingStatus::NotAlerting;
-            }
+            self.set_alerting_status(AlertingStatus::NotAlerting);
         }
 
         Ok(())
@@ -240,7 +237,7 @@ impl MemorySlotTimeMonitor {
         if let Some(state) = self.state.as_mut()
             && state.alerting_status != AlertingStatus::SlowSlotTime
         {
-            state.alerting_status = AlertingStatus::SlowSlotTime;
+            self.set_alerting_status(AlertingStatus::SlowSlotTime);
             self.config
                 .alert_tx
                 .send(Alert::new(
@@ -268,7 +265,7 @@ impl MemorySlotTimeMonitor {
         if let Some(state) = self.state.as_mut()
             && state.alerting_status != AlertingStatus::FastSlotTime
         {
-            state.alerting_status = AlertingStatus::FastSlotTime;
+            self.set_alerting_status(AlertingStatus::FastSlotTime);
             self.config
                 .alert_tx
                 .send(Alert::new(
@@ -283,5 +280,12 @@ impl MemorySlotTimeMonitor {
                 .await?;
         }
         Ok(())
+    }
+
+    /// Helper function to set the alerting status.
+    fn set_alerting_status(&mut self, alert_status: AlertingStatus) {
+        if let Some(state) = self.state.as_mut() {
+            state.alerting_status = alert_status;
+        }
     }
 }

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -214,10 +214,10 @@ impl MemorySlotTimeMonitor {
         };
 
         if slot_diff_per_time_diff < self.config.slow_slots_threshold {
-            self.send_slow_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
+            self.send_slow_slot_time_alert(slot_diff, slot_diff_per_time_diff, *block_info, mode)
                 .await?;
         } else if slot_diff_per_time_diff > self.config.fast_slots_threshold {
-            self.send_fast_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
+            self.send_fast_slot_time_alert(slot_diff, slot_diff_per_time_diff, *block_info, mode)
                 .await?;
         } else {
             self.set_alerting_status(AlertingStatus::NotAlerting);
@@ -229,6 +229,7 @@ impl MemorySlotTimeMonitor {
     /// Send a slot time alert with the computed ratio and block info.
     async fn send_slow_slot_time_alert(
         &mut self,
+        slot_diff: u64,
         slot_diff_per_time_diff: f64,
         block_info: BlockInfo,
         mode: BlockCheckMode,
@@ -242,6 +243,7 @@ impl MemorySlotTimeMonitor {
                 .alert_tx
                 .send(Alert::new(
                     AlertKind::SlowSlotTime {
+                        slot_amount: slot_diff,
                         current_ratio: slot_diff_per_time_diff,
                         threshold: self.config.slow_slots_threshold,
                         interval: self.config.check_interval,
@@ -257,6 +259,7 @@ impl MemorySlotTimeMonitor {
     /// Send a fast slot time alert with the computed ratio and block info.
     async fn send_fast_slot_time_alert(
         &mut self,
+        slot_diff: u64,
         slot_diff_per_time_diff: f64,
         block_info: BlockInfo,
         mode: BlockCheckMode,
@@ -270,6 +273,7 @@ impl MemorySlotTimeMonitor {
                 .alert_tx
                 .send(Alert::new(
                     AlertKind::FastSlotTime {
+                        slot_amount: slot_diff,
                         current_ratio: slot_diff_per_time_diff,
                         threshold: self.config.fast_slots_threshold,
                         interval: self.config.check_interval,

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -62,9 +62,8 @@ pub struct MemorySlotTimeMonitor {
 
 /// State tracked by the slot time monitor, and updated at the same time.
 ///
-/// Reorgs are effectively ignored in the slot time state.
-/// If the chain passes `next_check_time` before the reorg, then the reorg will be a long way
-/// behind the new `next_check_time`.
+/// Reorgs will provoke to reduce the block height check window since some blocks heights will be
+/// duplicated, which is not precise but good enough for the slot time monitor.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SlotTimeMonitorState {
     /// Block buffer

--- a/chain-alerter/src/slot_time_monitor.rs
+++ b/chain-alerter/src/slot_time_monitor.rs
@@ -213,10 +213,10 @@ impl MemorySlotTimeMonitor {
             result
         };
 
-        if slot_diff_per_time_diff > self.config.slow_slots_threshold {
+        if slot_diff_per_time_diff < self.config.slow_slots_threshold {
             self.send_slow_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
                 .await?;
-        } else if slot_diff_per_time_diff < self.config.fast_slots_threshold {
+        } else if slot_diff_per_time_diff > self.config.fast_slots_threshold {
             self.send_fast_slot_time_alert(slot_diff_per_time_diff, *block_info, mode)
                 .await?;
         } else {


### PR DESCRIPTION
This PR closes #55 & #22

The update introduces the following:

- A buffer that is filled with the received
- During startup or while buffer isn't filled, alerts are ignored
- Adds `FastSlotTime` alert
- Updates `SlotTime` alert for `SlowSlotTime` alert 
- When a block is received it's pushed into the buffer (with a max length, removing the tail if necessary). Then, gets the tail & head of the buffer to check the `slot_per_time` and compares with the fast & slow thresholds, emitting an alert if needed.