### PR TITLE
Send actionable alerts to the production channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,11 @@ Other alert kinds are not de-duplicated.
 4. Build and run
    - `cargo run -- --name "My Test Bot" --icon "warning" --node-rpc-url wss://rpc.mainnet.subspace.foundation/ws`
      - public node URLs are [listed in subspace.rs](https://github.com/autonomys/subspace-chain-alerts/blob/ac33ed7d200a1fdc3b92c1919f7b9cfacfba37c6/chain-alerter/src/subspace.rs#L43-L49)
+     - `--production` will sent alerts to the production channel (except for startup alerts, which always go to the test channel)
      - `--slack=false` will disable Slack message posting entirely, and just log alerts to the terminal.
      - `--alert-limit=5` will exit after 5 alerts have been posted, including the startup alert.
    - On first observed block, you should see a Slack message in `#chain-alerts-test` summarizing connection and block info.
-   - All arguments are optional. The default node is `localhost`, and the default icon is the instance external IP address country flag (looked up via an online GeoIP service, which can be wrong).
+   - All arguments are optional.The default node is `localhost`, and the default icon is the instance external IP address country flag (looked up via an online GeoIP service, which can be wrong).
    - `RUST_LOG` can be used to filter logs, see:
      <https://docs.rs/tracing-subscriber/0.3.19/tracing_subscriber/filter/struct.EnvFilter.html#directives>
 

--- a/chain-alerter/src/alerts.rs
+++ b/chain-alerter/src/alerts.rs
@@ -588,6 +588,31 @@ impl Display for AlertKind {
 }
 
 impl AlertKind {
+    /// Returns true if the alert always goes to the test channel.
+    pub fn is_test_alert(&self) -> bool {
+        match self {
+            Self::Startup => true,
+            Self::BlockProductionStall { .. }
+            | Self::BlockProductionResumed { .. }
+            | Self::NewSideFork { .. }
+            | Self::SideForkExtended { .. }
+            | Self::Reorg { .. }
+            | Self::ForceBalanceTransfer { .. }
+            | Self::LargeBalanceTransfer { .. }
+            | Self::LargeBalanceTransferEvent { .. }
+            | Self::ImportantAddressTransfer { .. }
+            | Self::ImportantAddressTransferEvent { .. }
+            | Self::ImportantAddressExtrinsic { .. }
+            | Self::ImportantAddressEvent { .. }
+            | Self::SudoCall { .. }
+            | Self::SudoEvent { .. }
+            | Self::OperatorSlashed { .. }
+            | Self::SlotTime { .. }
+            | Self::FarmersDecreasedSuddenly { .. }
+            | Self::FarmersIncreasedSuddenly { .. } => false,
+        }
+    }
+
     /// Returns true if this alert is always a duplicate of another alert.
     pub fn is_duplicate(&self) -> bool {
         match self {

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -61,10 +61,6 @@ const ALERT_BUFFER_SIZE: usize = 100;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about)]
 struct Args {
-    /// The name used by the bot when posting alerts to Slack.
-    #[arg(long, default_value = "Dev")]
-    name: String,
-
     /// The Slack icon used by the bot when posting.
     ///
     /// Uses Short Names (but without the ':') from:
@@ -74,20 +70,25 @@ struct Args {
     #[arg(long)]
     icon: Option<String>,
 
+    /// The name used by the bot when posting alerts to Slack.
+    #[arg(long, default_value = "Dev")]
+    name: String,
+
     /// The RPC URL of the node to connect to.
     /// Uses the local node by default.
     #[arg(long, value_hint = ValueHint::Url, default_value = LOCAL_SUBSPACE_NODE_URL)]
     node_rpc_url: String,
 
-    /// Enable or disable Slack message posting.
-    /// Slack is enabled by default, and required a Slack OAuth secret file named `slack-secret`.
-    #[arg(long, default_value = "true", action = ArgAction::Set)]
-    slack: bool,
-
+    // Integration testing options
     /// Exit after this many alerts have been posted. Mainly used for testing.
     /// Default is no limit.
     #[arg(long)]
     alert_limit: Option<usize>,
+
+    /// Enable or disable Slack message posting.
+    /// Slack is enabled by default, and required a Slack OAuth secret file named `slack-secret`.
+    #[arg(long, default_value = "true", action = ArgAction::Set)]
+    slack: bool,
 }
 
 /// Initialize once-off setup for the chain alerter.

--- a/chain-alerter/src/main.rs
+++ b/chain-alerter/src/main.rs
@@ -79,6 +79,10 @@ struct Args {
     #[arg(long, value_hint = ValueHint::Url, default_value = LOCAL_SUBSPACE_NODE_URL)]
     node_rpc_url: String,
 
+    /// Send alerts to the production Slack channel.
+    #[arg(long, alias = "prod", default_value = "false", action = ArgAction::SetTrue)]
+    production: bool,
+
     // Integration testing options
     /// Exit after this many alerts have been posted. Mainly used for testing.
     /// Default is no limit.
@@ -131,6 +135,7 @@ async fn setup(
     let slack_client_info = if args.slack {
         Some(
             SlackClientInfo::new(
+                args.production,
                 &args.name,
                 args.icon.clone(),
                 &args.node_rpc_url,

--- a/chain-alerter/src/subspace/tests.rs
+++ b/chain-alerter/src/subspace/tests.rs
@@ -16,9 +16,6 @@ use tokio::sync::mpsc;
 use tracing::info;
 
 /// The type of the sharedfoundation and labs subspace clients.
-///
-/// The Arcs make sure shared clients and tasks are never dropped. (Because `&'static T` can
-/// implicitly be converted to `T`.)
 pub type SubspaceSetup = (
     SubspaceClient,
     RawRpcClient,


### PR DESCRIPTION
This PR adds a `--production` argument, which sends actionable alerts to the `#chain-alerts` channel.

Close #57 