### PR TITLE
feat: add staking indexer with operator tracking, share prices, and API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures-util",
+ "hex",
  "hex-literal",
  "parity-scale-codec",
  "pgtemp",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -12,6 +12,7 @@ actix-cors.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env"] }
 futures-util.workspace = true
+hex.workspace = true
 parity-scale-codec = { workspace = true, features = ["derive"] }
 rust_decimal.workspace = true
 scale-encode.workspace = true

--- a/indexer/migrations/0004_staking.sql
+++ b/indexer/migrations/0004_staking.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS indexer.operator_epoch_share_prices
+(
+    operator_id  BIGINT          NOT NULL,
+    domain_id    INTEGER         NOT NULL,
+    epoch_index  BIGINT          NOT NULL,
+    share_price  NUMERIC(28, 18) NOT NULL,
+    total_stake  NUMERIC(39, 0)  NOT NULL,
+    total_shares NUMERIC(39, 0)  NOT NULL,
+    block_height BIGINT          NOT NULL,
+    block_time   TIMESTAMPTZ     NOT NULL,
+    PRIMARY KEY (operator_id, domain_id, epoch_index)
+);
+
+CREATE INDEX IF NOT EXISTS op_epoch_sp_time_idx
+    ON indexer.operator_epoch_share_prices (operator_id, block_time DESC);
+
+CREATE TABLE IF NOT EXISTS indexer.nominators
+(
+    operator_id  BIGINT NOT NULL,
+    address      TEXT   NOT NULL,
+    status       TEXT   NOT NULL DEFAULT 'active',
+    block_height BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (operator_id, address)
+);
+
+CREATE INDEX IF NOT EXISTS nominators_operator_status_idx
+    ON indexer.nominators (operator_id, status);
+
+CREATE TABLE IF NOT EXISTS indexer.operators
+(
+    operator_id               BIGINT         NOT NULL PRIMARY KEY,
+    domain_id                 INTEGER        NOT NULL,
+    owner_account             TEXT           NOT NULL,
+    signing_key               TEXT           NOT NULL,
+    minimum_nominator_stake   NUMERIC(39, 0) NOT NULL,
+    nomination_tax            SMALLINT       NOT NULL,
+    status                    TEXT           NOT NULL DEFAULT 'registered',
+    total_stake               NUMERIC(39, 0) NOT NULL DEFAULT 0,
+    total_shares              NUMERIC(39, 0) NOT NULL DEFAULT 0,
+    total_storage_fee_deposit NUMERIC(39, 0) NOT NULL DEFAULT 0,
+    updated_at                TIMESTAMPTZ    NOT NULL DEFAULT now()
+);

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -1,7 +1,9 @@
 use crate::WebState;
 use crate::error::Error;
+use crate::staking::CHECKPOINT_KEY as STAKING_CHECKPOINT_KEY;
+use crate::storage::{OperatorRow, SharePriceRow};
 use crate::types::{ChainId, DomainId};
-use crate::xdm::get_processor_key;
+use crate::xdm::get_xdm_processor_key;
 use actix_web::{Responder, get, web};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -10,6 +12,7 @@ use shared::subspace::BlockNumber;
 use tokio::try_join;
 
 const MAX_RECENT_TRANSFERS: u64 = 10;
+const MAX_SHARE_PRICE_LIMIT: i64 = 50;
 
 pub(crate) fn health_config(cfg: &mut web::ServiceConfig) {
     cfg.service(health_check);
@@ -19,20 +22,22 @@ pub(crate) fn health_config(cfg: &mut web::ServiceConfig) {
 pub(crate) struct Health {
     consensus_processed_block_number: BlockNumber,
     auto_evm_processed_block_number: BlockNumber,
+    staking_processed_block_number: BlockNumber,
 }
 
 #[get("/health")]
 async fn health_check(data: web::Data<WebState>) -> Result<impl Responder, Error> {
-    let cn_key = get_processor_key(&ChainId::Consensus);
-    let aen_key = get_processor_key(&ChainId::Domain(DomainId(0)));
-    let (cn, aen) = try_join!(
+    let cn_key = get_xdm_processor_key(&ChainId::Consensus);
+    let aen_key = get_xdm_processor_key(&ChainId::Domain(DomainId(0)));
+    let (cn, aen, staking) = try_join!(
         data.db.get_last_processed_block(&cn_key),
         data.db.get_last_processed_block(&aen_key),
+        data.db.get_last_processed_block(STAKING_CHECKPOINT_KEY),
     )?;
-
     Ok(web::Json(Health {
         consensus_processed_block_number: cn,
         auto_evm_processed_block_number: aen,
+        staking_processed_block_number: staking,
     }))
 }
 
@@ -76,13 +81,13 @@ async fn xdm_address_transfers(
 ) -> Result<impl Responder, Error> {
     let address = path.into_inner();
     let decimal_scale = data.decimal_scale;
-    let transfers = data
+    let transfers: Vec<XdmTransfer> = data
         .db
         .get_xdm_transfer_for_address(&address)
         .await?
         .into_iter()
         .map(|transfer| (decimal_scale, transfer).into())
-        .collect::<Vec<XdmTransfer>>();
+        .collect();
     Ok(web::Json(transfers))
 }
 
@@ -108,12 +113,163 @@ async fn recent_xdm_transfers(
         limit
     };
     let decimal_scale = data.decimal_scale;
-    let transfers = data
+    let transfers: Vec<XdmTransfer> = data
         .db
         .get_recent_xdm_transfers(limit)
         .await?
         .into_iter()
         .map(|transfer| (decimal_scale, transfer).into())
-        .collect::<Vec<XdmTransfer>>();
+        .collect();
     Ok(web::Json(transfers))
+}
+
+pub(crate) fn staking_config(cfg: &mut web::ServiceConfig) {
+    cfg.service(
+        web::scope("/v1/staking").service(
+            web::scope("/operators").service(get_all_operators).service(
+                web::scope("/{operator_id}")
+                    .service(get_operator)
+                    .service(operator_share_prices)
+                    .service(operator_nominator_count),
+            ),
+        ),
+    );
+}
+
+#[derive(Serialize)]
+struct OperatorResponse {
+    id: String,
+    domain_id: String,
+    owner_account: String,
+    signing_key: String,
+    minimum_nominator_stake: String,
+    nomination_tax: u8,
+    total_stake: String,
+    total_shares: String,
+    total_storage_fee_deposit: String,
+    status: String,
+}
+
+fn map_operator_row(row: OperatorRow) -> OperatorResponse {
+    OperatorResponse {
+        id: row.operator_id,
+        domain_id: row.domain_id,
+        owner_account: row.owner_account,
+        signing_key: row.signing_key,
+        minimum_nominator_stake: row.minimum_nominator_stake,
+        nomination_tax: row.nomination_tax as u8,
+        total_stake: row.total_stake,
+        total_shares: row.total_shares,
+        total_storage_fee_deposit: row.total_storage_fee_deposit,
+        status: row.status,
+    }
+}
+
+#[get("")]
+async fn get_all_operators(data: web::Data<WebState>) -> Result<impl Responder, Error> {
+    let operators: Vec<OperatorResponse> = data
+        .db
+        .get_all_operators()
+        .await?
+        .into_iter()
+        .map(map_operator_row)
+        .collect();
+    Ok(web::Json(operators))
+}
+
+#[get("")]
+async fn get_operator(
+    data: web::Data<WebState>,
+    path: web::Path<i64>,
+) -> Result<impl Responder, Error> {
+    let operator_id = path.into_inner();
+    match data.db.get_operator(operator_id).await? {
+        Some(row) => Ok(web::Json(map_operator_row(row))),
+        None => Err(Error::NotFound(format!("Operator {operator_id} not found"))),
+    }
+}
+
+#[derive(Deserialize)]
+struct SharePricesQuery {
+    #[serde(default = "default_share_price_limit")]
+    limit: i64,
+    since: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+}
+
+fn default_share_price_limit() -> i64 {
+    MAX_SHARE_PRICE_LIMIT
+}
+
+#[get("/share-prices")]
+async fn operator_share_prices(
+    data: web::Data<WebState>,
+    path: web::Path<i64>,
+    info: web::Query<SharePricesQuery>,
+) -> Result<impl Responder, Error> {
+    let operator_id = path.into_inner();
+    let SharePricesQuery {
+        limit,
+        since,
+        until,
+    } = info.into_inner();
+    let limit = limit.clamp(1, MAX_SHARE_PRICE_LIMIT);
+    let rows: Vec<SharePriceRow> = match (since, until) {
+        (Some(since), _) => {
+            data.db
+                .get_share_prices_since(operator_id, since, limit)
+                .await?
+        }
+        (_, Some(until)) => {
+            data.db
+                .get_share_prices_until(operator_id, until, limit)
+                .await?
+        }
+        _ => data.db.get_share_prices_latest(operator_id, limit).await?,
+    };
+    let response: Vec<_> = rows
+        .into_iter()
+        .map(|r| SharePriceResponse {
+            operator_id: r.operator_id,
+            domain_id: r.domain_id,
+            epoch_index: r.epoch_index,
+            share_price: r.share_price,
+            total_stake: r.total_stake,
+            total_shares: r.total_shares,
+            block_height: r.block_height,
+            timestamp: r.block_time,
+        })
+        .collect();
+    Ok(web::Json(response))
+}
+
+#[derive(Serialize)]
+struct SharePriceResponse {
+    operator_id: String,
+    domain_id: String,
+    epoch_index: i64,
+    share_price: String,
+    total_stake: String,
+    total_shares: String,
+    block_height: String,
+    timestamp: DateTime<Utc>,
+}
+
+#[derive(Serialize)]
+struct NominatorCountResponse {
+    operator_id: i64,
+    active_count: i64,
+}
+
+#[get("/nominators/count")]
+async fn operator_nominator_count(
+    data: web::Data<WebState>,
+    path: web::Path<i64>,
+) -> Result<impl Responder, Error> {
+    let operator_id = path.into_inner();
+    let active_count = data.db.get_active_nominator_count(operator_id).await?;
+    Ok(web::Json(NominatorCountResponse {
+        operator_id,
+        active_count,
+    }))
 }

--- a/indexer/src/error.rs
+++ b/indexer/src/error.rs
@@ -10,6 +10,11 @@ use tracing::error;
 pub(crate) enum Error {
     #[error("Config error: {0}")]
     Config(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[allow(dead_code)]
+    #[error("Bad request: {0}")]
+    BadRequest(String),
     #[error("Subspace error: {0}")]
     Subspace(#[from] shared::error::Error),
     #[error("Io error: {0}")]
@@ -32,11 +37,28 @@ impl From<subxt::Error> for Error {
 
 impl ResponseError for Error {
     fn status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
+        match self {
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 
     fn error_response(&self) -> HttpResponse {
-        error!("API error: {self}");
-        HttpResponse::build(self.status_code()).body("internal server error")
+        let body = match self {
+            Self::NotFound(msg) => {
+                tracing::warn!("API 404: {msg}");
+                format!("not found: {msg}")
+            }
+            Self::BadRequest(msg) => {
+                tracing::warn!("API 400: {msg}");
+                format!("bad request: {msg}")
+            }
+            other => {
+                error!("API error: {other}");
+                "internal server error".to_string()
+            }
+        };
+        HttpResponse::build(self.status_code()).body(body)
     }
 }

--- a/indexer/src/events.rs
+++ b/indexer/src/events.rs
@@ -1,0 +1,195 @@
+//! Event types that implement `subxt::events::StaticEvent`.
+//!
+//! XDM events (Transporter pallet) and staking events (Domains pallet).
+
+use crate::types::{ChainId, DomainId, Transfer, XdmMessageId};
+use scale_decode::DecodeAsType;
+use shared::subspace::Balance;
+use subxt::events::StaticEvent;
+use subxt::utils::AccountId32;
+
+#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
+pub(crate) struct OutgoingTransferInitiated {
+    pub(crate) chain_id: ChainId,
+    pub(crate) message_id: XdmMessageId,
+    pub(crate) amount: Balance,
+}
+
+impl StaticEvent for OutgoingTransferInitiated {
+    const PALLET: &'static str = "Transporter";
+    const EVENT: &'static str = "OutgoingTransferInitiated";
+}
+
+#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
+pub(crate) struct OutgoingTransferFailed {
+    pub(crate) chain_id: ChainId,
+    pub(crate) message_id: XdmMessageId,
+    // TODO: capture error as well
+}
+
+impl StaticEvent for OutgoingTransferFailed {
+    const PALLET: &'static str = "Transporter";
+    const EVENT: &'static str = "OutgoingTransferFailed";
+}
+
+impl From<OutgoingTransferFailed> for Event {
+    fn from(value: OutgoingTransferFailed) -> Self {
+        Event::OutgoingTransferFailed(value)
+    }
+}
+
+#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
+pub(crate) struct OutgoingTransferSuccessful {
+    pub(crate) chain_id: ChainId,
+    pub(crate) message_id: XdmMessageId,
+}
+
+impl StaticEvent for OutgoingTransferSuccessful {
+    const PALLET: &'static str = "Transporter";
+    const EVENT: &'static str = "OutgoingTransferSuccessful";
+}
+
+impl From<OutgoingTransferSuccessful> for Event {
+    fn from(value: OutgoingTransferSuccessful) -> Self {
+        Event::OutgoingTransferSuccessful(value)
+    }
+}
+
+#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
+pub(crate) struct IncomingTransferSuccessful {
+    pub(crate) chain_id: ChainId,
+    pub(crate) message_id: XdmMessageId,
+    pub(crate) amount: Balance,
+}
+
+impl StaticEvent for IncomingTransferSuccessful {
+    const PALLET: &'static str = "Transporter";
+    const EVENT: &'static str = "IncomingTransferSuccessful";
+}
+
+impl From<IncomingTransferSuccessful> for Event {
+    fn from(value: IncomingTransferSuccessful) -> Self {
+        Event::IncomingTransferSuccessful(value)
+    }
+}
+
+#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
+pub(crate) struct OutgoingTransferInitiatedWithTransfer {
+    pub(crate) message_id: XdmMessageId,
+    pub(crate) transfer: Transfer,
+}
+
+impl From<OutgoingTransferInitiatedWithTransfer> for Event {
+    fn from(value: OutgoingTransferInitiatedWithTransfer) -> Self {
+        Event::OutgoingTransferInitiated(value)
+    }
+}
+
+/// Overarching event type
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum Event {
+    OutgoingTransferInitiated(OutgoingTransferInitiatedWithTransfer),
+    OutgoingTransferFailed(OutgoingTransferFailed),
+    OutgoingTransferSuccessful(OutgoingTransferSuccessful),
+    IncomingTransferSuccessful(IncomingTransferSuccessful),
+}
+
+/// Emitted by pallet `Domains` after each epoch finalises share prices.
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct DomainEpochCompleted {
+    pub(crate) domain_id: DomainId,
+    /// EpochIndex is a type alias for u32 on-chain.
+    pub(crate) completed_epoch_index: u32,
+}
+
+impl StaticEvent for DomainEpochCompleted {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "DomainEpochCompleted";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorNominated {
+    pub(crate) operator_id: u64,
+    pub(crate) nominator_id: AccountId32,
+    // `amount` is present in the on-chain event but not needed here;
+    // DecodeAsType decodes by field-name matching so omitting it is safe.
+}
+
+impl StaticEvent for OperatorNominated {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorNominated";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct WithdrewStake {
+    pub(crate) operator_id: u64,
+    pub(crate) nominator_id: AccountId32,
+}
+
+impl StaticEvent for WithdrewStake {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "WithdrewStake";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct NominatorUnlocked {
+    pub(crate) operator_id: u64,
+    pub(crate) nominator_id: AccountId32,
+}
+
+impl StaticEvent for NominatorUnlocked {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "NominatorUnlocked";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorRegistered {
+    pub(crate) operator_id: u64,
+}
+
+impl StaticEvent for OperatorRegistered {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorRegistered";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorDeregistered {
+    pub(crate) operator_id: u64,
+}
+
+impl StaticEvent for OperatorDeregistered {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorDeregistered";
+}
+
+/// `reason` field is omitted — DecodeAsType matches by field name and skips unknowns.
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorSlashed {
+    pub(crate) operator_id: u64,
+}
+
+impl StaticEvent for OperatorSlashed {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorSlashed";
+}
+
+/// `reactivation_delay` is omitted — we only need operator_id.
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorDeactivated {
+    pub(crate) operator_id: u64,
+}
+
+impl StaticEvent for OperatorDeactivated {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorDeactivated";
+}
+
+#[derive(Debug, Clone, DecodeAsType)]
+pub(crate) struct OperatorReactivated {
+    pub(crate) operator_id: u64,
+}
+
+impl StaticEvent for OperatorReactivated {
+    const PALLET: &'static str = "Domains";
+    const EVENT: &'static str = "OperatorReactivated";
+}

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -3,6 +3,10 @@
 
 mod api;
 mod error;
+mod events;
+mod processor;
+mod rpc_types;
+mod staking;
 mod storage;
 mod types;
 mod xdm;
@@ -37,7 +41,7 @@ pub(crate) struct Cli {
         default_value = "postgres://indexer:password@localhost:5434/indexer?sslmode=disable"
     )]
     db_uri: String,
-    #[clap(long, env, default_value = "5000")]
+    #[clap(long, env, default_value = "1000")]
     process_blocks_in_parallel: u32,
 }
 
@@ -101,6 +105,7 @@ async fn main() -> Result<(), Error> {
             .app_data(web::Data::new(state))
             .configure(api::health_config)
             .configure(api::xdm_config)
+            .configure(api::staking_config)
     })
     .keep_alive(Duration::from_secs(30))
     .bind(("0.0.0.0", 8080))?
@@ -141,10 +146,13 @@ async fn start_tasks(
             .instrument(span.clone()),
     );
 
+    let is_consensus = matches!(chain, ChainId::Consensus);
+    let block_provider = subspace.block_provider();
+
     join_set.spawn(
         {
             let stream = subspace.blocks_stream();
-            let block_provider = subspace.block_provider();
+            let block_provider = block_provider.clone();
             let db = db.clone();
             async move {
                 xdm::index_xdm(
@@ -159,6 +167,24 @@ async fn start_tasks(
         }
         .instrument(span.clone()),
     );
+
+    // Spawn the staking processor only for the consensus chain.
+    // blocks_stream() is a broadcast resubscription so both processors
+    // receive every block independently.
+    if is_consensus {
+        join_set.spawn(
+            {
+                let stream = subspace.blocks_stream();
+                let block_provider = block_provider.clone();
+                let db = db.clone();
+                async move {
+                    staking::index_staking(stream, block_provider, db, process_blocks_in_parallel)
+                        .await
+                }
+            }
+            .instrument(span.clone()),
+        );
+    }
 
     // listen for all consensus blocks
     join_set.spawn(

--- a/indexer/src/processor.rs
+++ b/indexer/src/processor.rs
@@ -1,0 +1,105 @@
+//! Shared block-processing loop used by both `xdm` and `staking` processors.
+
+use crate::error::Error;
+use crate::storage::Db;
+use futures_util::{StreamExt, TryStreamExt, stream};
+use shared::subspace::{BlockNumber, BlocksStream, SubspaceBlockProvider};
+use tokio::sync::broadcast::error::RecvError;
+use tracing::info;
+
+const CHECKPOINT_PROCESSED_BLOCK: u32 = 100;
+
+/// Implemented by every block-level processor.
+/// The outer stream loop is provided by [`run_processor`].
+pub(crate) trait BlockProcessor {
+    /// Called once per block; performs all DB writes for that block.
+    async fn process_block(
+        &self,
+        block_number: BlockNumber,
+        db: &Db,
+        block_provider: &SubspaceBlockProvider,
+    ) -> Result<(), Error>;
+
+    /// The key used to checkpoint progress in `indexer.metadata`.
+    fn checkpoint_key(&self) -> &str;
+
+    /// Human-readable name for log messages.
+    fn name(&self) -> &str;
+}
+
+/// Drives the stream loop for any [`BlockProcessor`] implementor.
+pub(crate) async fn run_processor<P: BlockProcessor>(
+    processor: P,
+    mut stream: BlocksStream,
+    block_provider: SubspaceBlockProvider,
+    db: Db,
+    process_blocks_in_parallel: u32,
+) -> Result<(), Error> {
+    let checkpoint_key = processor.checkpoint_key().to_string();
+    let name = processor.name().to_string();
+    loop {
+        let blocks_ext = match stream.recv().await {
+            Ok(block_ext) => block_ext,
+            Err(RecvError::Lagged(_)) => continue,
+            Err(err) => return Err(err.into()),
+        };
+        let last_processed_block_number = db
+            .get_last_processed_block(&checkpoint_key)
+            .await
+            .unwrap_or(0);
+
+        let (from, to) = if blocks_ext.blocks.len() == 1 {
+            (
+                last_processed_block_number + 1,
+                blocks_ext
+                    .blocks
+                    .first()
+                    .expect("must contain at least one block")
+                    .number,
+            )
+        } else {
+            let blocks = blocks_ext
+                .blocks
+                .iter()
+                .map(|b| b.number)
+                .collect::<Vec<_>>();
+            let min = *blocks
+                .iter()
+                .min()
+                .expect("should have more than one block");
+            let max = *blocks
+                .iter()
+                .max()
+                .expect("should have more than one block");
+            (min.min(last_processed_block_number + 1), max)
+        };
+
+        if from > to {
+            continue;
+        }
+
+        info!("{name}: indexing blocks from[{from}] to[{to}]...");
+        let mut s = stream::iter((from..=to).map(|block| {
+            let processor = &processor;
+            let db = &db;
+            let block_provider = &block_provider;
+            async move {
+                processor
+                    .process_block(block, db, block_provider)
+                    .await
+                    .map(|_| block)
+            }
+        }))
+        .buffered(process_blocks_in_parallel as usize);
+
+        while let Some(block) = s.try_next().await? {
+            if block.is_multiple_of(CHECKPOINT_PROCESSED_BLOCK) {
+                info!("{name}: indexed block: {}", block);
+                db.set_last_processed_block(&checkpoint_key, block).await?;
+            }
+        }
+
+        info!("{name}: indexed block: {}", to);
+        db.set_last_processed_block(&checkpoint_key, to).await?;
+    }
+}

--- a/indexer/src/rpc_types.rs
+++ b/indexer/src/rpc_types.rs
@@ -1,0 +1,123 @@
+//! Decode types for live RPC storage reads (operator data only).
+//!
+//! These mirror the on-chain SCALE layout of pallet-domains.
+//! Manual `impl Decode` is used for types with skip-fields to avoid storing unused data.
+
+use parity_scale_codec::Decode;
+
+/// DomainEpoch(DomainId(u32), EpochIndex(u32)) — helper for manual decode only.
+/// Read two u32s and discard for the Deregistered variant.
+struct DomainEpochHelper;
+
+impl DomainEpochHelper {
+    fn skip<I: parity_scale_codec::Input>(input: &mut I) -> Result<(), parity_scale_codec::Error> {
+        let _ = u32::decode(input)?; // domain_id
+        let _ = u32::decode(input)?; // epoch_index
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) enum OperatorStatusCompact {
+    Registered,
+    Deregistered,
+    Slashed,
+    PendingSlash,
+    InvalidBundle([u8; 32]),
+    Deactivated,
+}
+
+impl OperatorStatusCompact {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Registered => "registered",
+            Self::Deregistered => "deregistered",
+            Self::Slashed => "slashed",
+            Self::PendingSlash => "pending_slash",
+            Self::InvalidBundle(_) => "invalid_bundle",
+            Self::Deactivated => "deactivated",
+        }
+    }
+}
+
+impl Decode for OperatorStatusCompact {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let variant = u8::decode(input)?;
+        match variant {
+            0 => Ok(Self::Registered),
+            1 => {
+                // Deregistered { domain_epoch: DomainEpoch, unlock_at_block: u32 }
+                DomainEpochHelper::skip(input)?;
+                let _ = u32::decode(input)?; // unlock_at_block
+                Ok(Self::Deregistered)
+            }
+            2 => Ok(Self::Slashed),
+            3 => Ok(Self::PendingSlash),
+            4 => {
+                let hash = <[u8; 32] as Decode>::decode(input)?;
+                Ok(Self::InvalidBundle(hash))
+            }
+            5 => {
+                let _ = u32::decode(input)?; // at_epoch_index
+                Ok(Self::Deactivated)
+            }
+            n => Err(
+                parity_scale_codec::Error::from("Unknown OperatorStatus variant")
+                    .chain(format!("variant index: {n}")),
+            ),
+        }
+    }
+}
+
+/// On-chain SCALE layout (Autonomys mainnet):
+///   signing_key:                [u8; 32]
+///   current_domain_id:          u32
+///   next_domain_id:             u32   (skipped)
+///   minimum_nominator_stake:    u128
+///   nomination_tax:             u8
+///   current_total_stake:        u128
+///   current_total_shares:       u128
+///   status:                     OperatorStatus (enum)
+///   deposits_in_epoch:          u128  (skipped)
+///   withdrawals_in_epoch:       u128  (skipped)
+///   total_storage_fee_deposit:  u128
+pub(crate) struct FullOperator {
+    pub(crate) signing_key: [u8; 32],
+    pub(crate) current_domain_id: u32,
+    pub(crate) minimum_nominator_stake: u128,
+    pub(crate) nomination_tax: u8,
+    pub(crate) current_total_stake: u128,
+    pub(crate) current_total_shares: u128,
+    pub(crate) status: OperatorStatusCompact,
+    pub(crate) total_storage_fee_deposit: u128,
+}
+
+impl Decode for FullOperator {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let signing_key = <[u8; 32] as Decode>::decode(input)?;
+        let current_domain_id = u32::decode(input)?;
+        let _ = u32::decode(input)?; // next_domain_id
+        let minimum_nominator_stake = u128::decode(input)?;
+        let nomination_tax = u8::decode(input)?;
+        let current_total_stake = u128::decode(input)?;
+        let current_total_shares = u128::decode(input)?;
+        let status = OperatorStatusCompact::decode(input)?;
+        let _ = u128::decode(input)?; // deposits_in_epoch
+        let _ = u128::decode(input)?; // withdrawals_in_epoch
+        let total_storage_fee_deposit = u128::decode(input)?;
+        Ok(Self {
+            signing_key,
+            current_domain_id,
+            minimum_nominator_stake,
+            nomination_tax,
+            current_total_stake,
+            current_total_shares,
+            status,
+            total_storage_fee_deposit,
+        })
+    }
+}

--- a/indexer/src/staking.rs
+++ b/indexer/src/staking.rs
@@ -1,0 +1,619 @@
+use crate::error::Error;
+use crate::events::{
+    DomainEpochCompleted, NominatorUnlocked, OperatorDeactivated, OperatorDeregistered,
+    OperatorNominated, OperatorReactivated, OperatorRegistered, OperatorSlashed, WithdrewStake,
+};
+use crate::processor::{self, BlockProcessor};
+use crate::rpc_types::FullOperator;
+use crate::storage::{Db, UpsertOperator, UpsertSharePrice};
+use crate::types::{DomainEpoch, StakingSummary};
+use chrono::DateTime;
+use rust_decimal::Decimal;
+use shared::subspace::{BlockNumber, BlocksStream, SubspaceBlockProvider};
+use subxt::storage::StaticStorageKey;
+use subxt::utils::AccountId32 as SubxtAccountId32;
+
+pub(crate) const CHECKPOINT_KEY: &str = "staking_processor_Consensus";
+
+pub(crate) struct StakingProcessor;
+
+impl BlockProcessor for StakingProcessor {
+    async fn process_block(
+        &self,
+        block_number: BlockNumber,
+        db: &Db,
+        block_provider: &SubspaceBlockProvider,
+    ) -> Result<(), Error> {
+        index_staking_for_block(block_number, db, block_provider).await
+    }
+
+    fn checkpoint_key(&self) -> &str {
+        CHECKPOINT_KEY
+    }
+
+    fn name(&self) -> &str {
+        "Staking"
+    }
+}
+
+pub(crate) async fn index_staking(
+    stream: BlocksStream,
+    block_provider: SubspaceBlockProvider,
+    db: Db,
+    process_blocks_in_parallel: u32,
+) -> Result<(), Error> {
+    processor::run_processor(
+        StakingProcessor,
+        stream,
+        block_provider,
+        db,
+        process_blocks_in_parallel,
+    )
+    .await
+}
+
+async fn index_staking_for_block(
+    block_number: BlockNumber,
+    db: &Db,
+    block_provider: &SubspaceBlockProvider,
+) -> Result<(), Error> {
+    let block_ext = block_provider.block_ext_at_number(block_number).await?;
+    let block_time = DateTime::from_timestamp_millis(block_ext.timestamp().await? as i64)
+        .expect("should always be a valid Unix epoch time");
+    let events = block_ext.events().await?;
+
+    for event in events.find::<OperatorRegistered>() {
+        let e = event?;
+        let op: FullOperator = match block_ext
+            .read_storage("Domains", "Operators", StaticStorageKey::new(e.operator_id))
+            .await
+        {
+            Ok(op) => op,
+            Err(_) => continue,
+        };
+        let owner: SubxtAccountId32 = match block_ext
+            .read_storage(
+                "Domains",
+                "OperatorIdOwner",
+                StaticStorageKey::new(e.operator_id),
+            )
+            .await
+        {
+            Ok(owner) => owner,
+            Err(_) => continue,
+        };
+        let owner_account = sp_core::crypto::AccountId32::new(owner.0).to_string();
+        let signing_key_hex = format!("0x{}", hex::encode(op.signing_key));
+        db.upsert_operator(UpsertOperator {
+            operator_id: e.operator_id,
+            domain_id: op.current_domain_id,
+            owner_account,
+            signing_key: signing_key_hex,
+            minimum_nominator_stake: op.minimum_nominator_stake,
+            nomination_tax: op.nomination_tax,
+            status: op.status.as_str().to_string(),
+            total_stake: op.current_total_stake,
+            total_shares: op.current_total_shares,
+            total_storage_fee_deposit: op.total_storage_fee_deposit,
+            block_time,
+        })
+        .await?;
+    }
+
+    for event in events.find::<OperatorDeregistered>() {
+        let e = event?;
+        db.update_operator_status(e.operator_id, "deregistered")
+            .await?;
+    }
+
+    for event in events.find::<OperatorSlashed>() {
+        let e = event?;
+        db.update_operator_status(e.operator_id, "slashed").await?;
+    }
+
+    for event in events.find::<OperatorDeactivated>() {
+        let e = event?;
+        db.update_operator_status(e.operator_id, "deactivated")
+            .await?;
+    }
+
+    for event in events.find::<OperatorReactivated>() {
+        let e = event?;
+        db.update_operator_status(e.operator_id, "registered")
+            .await?;
+    }
+
+    for event in events.find::<OperatorNominated>() {
+        let e = event?;
+        let address = sp_core::crypto::AccountId32::new(e.nominator_id.0).to_string();
+        db.upsert_nominator(e.operator_id, &address, "active", block_number)
+            .await?;
+    }
+
+    for event in events.find::<WithdrewStake>() {
+        let e = event?;
+        let address = sp_core::crypto::AccountId32::new(e.nominator_id.0).to_string();
+        db.upsert_nominator(e.operator_id, &address, "withdrawn", block_number)
+            .await?;
+    }
+
+    for event in events.find::<NominatorUnlocked>() {
+        let e = event?;
+        let address = sp_core::crypto::AccountId32::new(e.nominator_id.0).to_string();
+        db.upsert_nominator(e.operator_id, &address, "withdrawn", block_number)
+            .await?;
+    }
+
+    for event in events.find::<DomainEpochCompleted>() {
+        let e = event?;
+        index_epoch_share_prices(&block_ext, &e, block_number, block_time, db).await?;
+    }
+
+    Ok(())
+}
+
+async fn index_epoch_share_prices(
+    block_ext: &shared::subspace::BlockExt,
+    epoch_event: &DomainEpochCompleted,
+    block_height: BlockNumber,
+    block_time: DateTime<chrono::Utc>,
+    db: &Db,
+) -> Result<(), Error> {
+    let domain_id = epoch_event.domain_id.clone();
+    let epoch_index = epoch_event.completed_epoch_index;
+
+    // Fetch the staking summary for this domain to get the active operator set.
+    let summary: StakingSummary = block_ext
+        .read_storage(
+            "Domains",
+            "DomainStakingSummary",
+            StaticStorageKey::new(domain_id.clone()),
+        )
+        .await?;
+
+    for operator_id in summary.current_operators.keys() {
+        let domain_epoch = DomainEpoch(domain_id.clone(), epoch_index);
+
+        // Read the share price for this operator + epoch (OptionQuery — may be absent).
+        let share_price_raw = match block_ext
+            .read_storage::<_, u64>(
+                "Domains",
+                "OperatorEpochSharePrice",
+                (
+                    StaticStorageKey::new(*operator_id),
+                    StaticStorageKey::new(domain_epoch),
+                ),
+            )
+            .await
+        {
+            Ok(price) => price,
+            Err(_) => continue,
+        };
+
+        // Read full operator data for stake/shares/status/storage-fee.
+        let op: FullOperator = match block_ext
+            .read_storage("Domains", "Operators", StaticStorageKey::new(*operator_id))
+            .await
+        {
+            Ok(op) => op,
+            Err(_) => continue,
+        };
+
+        // Convert Perquintill to decimal: raw_u64 / 10^18
+        let share_price =
+            Decimal::from(share_price_raw) / Decimal::from(1_000_000_000_000_000_000u64);
+
+        db.upsert_epoch_share_price(UpsertSharePrice {
+            operator_id: *operator_id as i64,
+            domain_id: domain_id.0 as i32,
+            epoch_index: epoch_index as i64,
+            share_price,
+            total_stake: op.current_total_stake,
+            total_shares: op.current_total_shares,
+            block_height: block_height as i64,
+            block_time,
+        })
+        .await?;
+
+        // Update operator stats in the operators table (only mutable fields).
+        // This won't insert a new row — only updates existing ones indexed via
+        // OperatorRegistered. If operator isn't in DB yet, this is a no-op.
+        db.update_operator_stats(
+            *operator_id,
+            op.status.as_str(),
+            op.current_total_stake,
+            op.current_total_shares,
+            op.total_storage_fee_deposit,
+            block_time,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::{
+        DomainEpochCompleted, OperatorNominated, OperatorRegistered, WithdrewStake,
+    };
+    use crate::rpc_types::FullOperator;
+    use crate::storage::{Db, UpsertOperator};
+    use pgtemp::{PgTempDB, PgTempDBBuilder};
+    use shared::subspace::Subspace;
+    use std::str::FromStr;
+    use subxt::storage::StaticStorageKey;
+    use subxt::utils::{AccountId32 as SubxtAccountId32, H256};
+
+    const RPC_URL: &str = "wss://rpc.mainnet.autonomys.xyz/ws";
+
+    // Block hashes containing known staking events
+    const OPERATOR_REGISTERED_HASH: &str =
+        "0x9749ce3959c6e613a85f1576331ebb138aa3f00492dcde3b37ae978bb399c364";
+    const DOMAIN_EPOCH_COMPLETED_HASH: &str =
+        "0xb26dc651dd8317b593775da3202061dd0c1dea817e0e60c5f0f4b14c6f9efb39";
+    const WITHDREW_STAKE_HASH: &str =
+        "0xe70e7da10ae1fa68f5e274e6f673ae6933386e688284186dec88fc2870f38e24";
+    const OPERATOR_NOMINATED_HASH: &str =
+        "0x5df7664c6e14422fdbbc68f5d78f4252e2151bce887b9659e4eea53df59e3f74";
+
+    struct TestDb {
+        db: Db,
+        _temp_db: PgTempDB,
+    }
+
+    async fn get_db() -> TestDb {
+        let temp_db = PgTempDBBuilder::new().start_async().await;
+        let db = Db::new(temp_db.connection_uri().as_str(), "./migrations")
+            .await
+            .unwrap();
+        TestDb {
+            db,
+            _temp_db: temp_db,
+        }
+    }
+
+    fn sample_operator(operator_id: u64) -> UpsertOperator {
+        UpsertOperator {
+            operator_id,
+            domain_id: 0,
+            owner_account: format!("owner_{operator_id}"),
+            signing_key: format!("0xsigning_key_{operator_id}"),
+            minimum_nominator_stake: 1_000_000_000_000_000_000,
+            nomination_tax: 5,
+            status: "registered".to_string(),
+            total_stake: 50_000_000_000_000_000_000,
+            total_shares: 50_000_000_000_000_000_000,
+            total_storage_fee_deposit: 1_000_000_000_000_000_000,
+            block_time: chrono::DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
+        }
+    }
+
+    // ── Event-only decode tests (RPC, no DB) ─────────────────────────
+
+    #[tokio::test]
+    async fn test_decode_operator_registered() {
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(OPERATOR_REGISTERED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let events = block_ext.events().await.unwrap();
+
+        let registered: Vec<_> = events
+            .find::<OperatorRegistered>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            !registered.is_empty(),
+            "should find OperatorRegistered event"
+        );
+        let e = &registered[0];
+        assert!(e.operator_id > 0, "operator_id should be > 0");
+
+        // Verify full storage decode path: read FullOperator + OperatorIdOwner
+        let op: FullOperator = block_ext
+            .read_storage("Domains", "Operators", StaticStorageKey::new(e.operator_id))
+            .await
+            .unwrap();
+        assert!(
+            op.current_total_stake > 0 || op.current_total_shares > 0,
+            "operator should have stake or shares"
+        );
+
+        let _owner: SubxtAccountId32 = block_ext
+            .read_storage(
+                "Domains",
+                "OperatorIdOwner",
+                StaticStorageKey::new(e.operator_id),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_decode_operator_nominated() {
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(OPERATOR_NOMINATED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let events = block_ext.events().await.unwrap();
+
+        let nominated: Vec<_> = events
+            .find::<OperatorNominated>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!nominated.is_empty(), "should find OperatorNominated event");
+        let e = &nominated[0];
+        assert!(e.operator_id > 0, "operator_id should be > 0");
+        assert_ne!(
+            e.nominator_id.0, [0u8; 32],
+            "nominator_id should not be all zeros"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_withdrew_stake() {
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(WITHDREW_STAKE_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let events = block_ext.events().await.unwrap();
+
+        let withdrew: Vec<_> = events
+            .find::<WithdrewStake>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!withdrew.is_empty(), "should find WithdrewStake event");
+        let e = &withdrew[0];
+        assert_ne!(
+            e.nominator_id.0, [0u8; 32],
+            "nominator_id should not be all zeros"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_decode_domain_epoch_completed() {
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(DOMAIN_EPOCH_COMPLETED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let events = block_ext.events().await.unwrap();
+
+        let completed: Vec<_> = events
+            .find::<DomainEpochCompleted>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            !completed.is_empty(),
+            "should find DomainEpochCompleted event"
+        );
+        let e = &completed[0];
+        assert!(e.completed_epoch_index > 0, "epoch index should be > 0");
+    }
+
+    // ── End-to-end tests (RPC + pgtemp DB) ───────────────────────────
+
+    #[tokio::test]
+    async fn test_index_staking_operator_registered() {
+        let test_db = get_db().await;
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(OPERATOR_REGISTERED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let block_number = block_ext.number;
+
+        index_staking_for_block(block_number, &test_db.db, &subspace)
+            .await
+            .unwrap();
+
+        // Find what operator_id was registered in this block
+        let events = block_ext.events().await.unwrap();
+        let registered: Vec<_> = events
+            .find::<OperatorRegistered>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!registered.is_empty());
+        let operator_id = registered[0].operator_id;
+
+        // Verify operator was inserted into DB
+        let row = test_db.db.get_operator(operator_id as i64).await.unwrap();
+        assert!(row.is_some(), "operator should exist in DB after indexing");
+        let row = row.unwrap();
+        assert_eq!(row.operator_id, operator_id.to_string());
+        assert_eq!(row.status, "registered");
+        assert!(
+            !row.signing_key.is_empty(),
+            "signing_key should be populated"
+        );
+        assert!(
+            row.signing_key.starts_with("0x"),
+            "signing_key should be hex"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_staking_operator_nominated() {
+        let test_db = get_db().await;
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        // First, decode the event to learn which operator_id is referenced
+        let block_hash = H256::from_str(OPERATOR_NOMINATED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let block_number = block_ext.number;
+        let events = block_ext.events().await.unwrap();
+        let nominated: Vec<_> = events
+            .find::<OperatorNominated>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!nominated.is_empty());
+        let operator_id = nominated[0].operator_id;
+
+        // Pre-insert the operator so the nominator upsert has a valid context
+        test_db
+            .db
+            .upsert_operator(sample_operator(operator_id))
+            .await
+            .unwrap();
+
+        // Run the indexer
+        index_staking_for_block(block_number, &test_db.db, &subspace)
+            .await
+            .unwrap();
+
+        // Verify nominator was inserted as active
+        let count = test_db
+            .db
+            .get_active_nominator_count(operator_id as i64)
+            .await
+            .unwrap();
+        assert!(
+            count > 0,
+            "at least one active nominator should exist after OperatorNominated"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_staking_withdrew_stake() {
+        let test_db = get_db().await;
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        // Decode the event to learn operator_id and nominator address
+        let block_hash = H256::from_str(WITHDREW_STAKE_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let block_number = block_ext.number;
+        let events = block_ext.events().await.unwrap();
+        let withdrew: Vec<_> = events
+            .find::<WithdrewStake>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!withdrew.is_empty());
+        let operator_id = withdrew[0].operator_id;
+        let nominator_address =
+            sp_core::crypto::AccountId32::new(withdrew[0].nominator_id.0).to_string();
+
+        // Pre-insert operator
+        test_db
+            .db
+            .upsert_operator(sample_operator(operator_id))
+            .await
+            .unwrap();
+
+        // Pre-insert nominator as "active" at an earlier block
+        test_db
+            .db
+            .upsert_nominator(operator_id, &nominator_address, "active", 1)
+            .await
+            .unwrap();
+        let count = test_db
+            .db
+            .get_active_nominator_count(operator_id as i64)
+            .await
+            .unwrap();
+        assert!(count > 0, "nominator should be active before withdrawal");
+
+        // Run the indexer for the WithdrewStake block
+        index_staking_for_block(block_number, &test_db.db, &subspace)
+            .await
+            .unwrap();
+
+        // Verify the specific nominator's status changed to withdrawn.
+        // (The block may also contain OperatorNominated events that add other
+        // active nominators for the same operator, so we query this nominator directly.)
+        let status: (String,) = sqlx::query_as(
+            "SELECT status FROM indexer.nominators WHERE operator_id = $1 AND address = $2",
+        )
+        .bind(operator_id as i64)
+        .bind(&nominator_address)
+        .fetch_one(&*test_db.db.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            status.0, "withdrawn",
+            "nominator should be withdrawn after WithdrewStake event"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_index_staking_domain_epoch_completed() {
+        let test_db = get_db().await;
+        let subspace = Subspace::new_from_url(RPC_URL)
+            .await
+            .unwrap()
+            .block_provider();
+
+        let block_hash = H256::from_str(DOMAIN_EPOCH_COMPLETED_HASH).unwrap();
+        let block_ext = subspace.block_ext_at_hash(block_hash).await.unwrap();
+        let block_number = block_ext.number;
+
+        // Decode the event to learn the domain_id
+        let events = block_ext.events().await.unwrap();
+        let completed: Vec<_> = events
+            .find::<DomainEpochCompleted>()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(!completed.is_empty());
+        let domain_id = completed[0].domain_id.clone();
+
+        // Read the staking summary for this domain to get active operators
+        let summary: crate::types::StakingSummary = block_ext
+            .read_storage(
+                "Domains",
+                "DomainStakingSummary",
+                StaticStorageKey::new(domain_id),
+            )
+            .await
+            .unwrap();
+        assert!(
+            !summary.current_operators.is_empty(),
+            "domain should have active operators"
+        );
+
+        // Pre-insert all active operators so update_operator_stats can update them
+        for &op_id in summary.current_operators.keys() {
+            test_db
+                .db
+                .upsert_operator(sample_operator(op_id))
+                .await
+                .unwrap();
+        }
+
+        // Run the indexer
+        index_staking_for_block(block_number, &test_db.db, &subspace)
+            .await
+            .unwrap();
+
+        // Verify share prices were stored for at least one operator
+        let first_op_id = *summary.current_operators.keys().next().unwrap();
+        let rows = test_db
+            .db
+            .get_share_prices_latest(first_op_id as i64, 10)
+            .await
+            .unwrap();
+        assert!(
+            !rows.is_empty(),
+            "share prices should be stored after DomainEpochCompleted"
+        );
+    }
+}

--- a/indexer/src/storage.rs
+++ b/indexer/src/storage.rs
@@ -1,12 +1,11 @@
 use crate::api;
 use crate::api::{BlockDetails, MaybeBlockDetails};
 use crate::error::Error;
-use crate::types::{
-    ChainId, Event, IncomingTransferSuccessful, Location, OutgoingTransferInitiatedWithTransfer,
-    Transfer, U128Compat, XdmMessageId,
-};
+use crate::events::{Event, IncomingTransferSuccessful, OutgoingTransferInitiatedWithTransfer};
+use crate::types::{ChainId, Location, Transfer, U128Compat, XdmMessageId};
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
+use serde::Serialize;
 use shared::subspace::{BlockNumber, HashAndNumber};
 use sqlx::PgPool;
 use std::ops::Div;
@@ -123,6 +122,58 @@ impl From<(Decimal, XdmTransfer)> for api::XdmTransfer {
             transfer_successful,
         }
     }
+}
+
+pub(crate) struct UpsertSharePrice {
+    pub(crate) operator_id: i64,
+    pub(crate) domain_id: i32,
+    pub(crate) epoch_index: i64,
+    pub(crate) share_price: Decimal,
+    pub(crate) total_stake: u128,
+    pub(crate) total_shares: u128,
+    pub(crate) block_height: i64,
+    pub(crate) block_time: DateTime<Utc>,
+}
+
+/// Row returned by share-price queries; field names match the
+/// `OperatorEpochSharePriceRow` TypeScript interface in auto-portal.
+#[derive(sqlx::FromRow, Serialize)]
+pub(crate) struct SharePriceRow {
+    pub(crate) operator_id: String,
+    pub(crate) domain_id: String,
+    pub(crate) epoch_index: i64,
+    pub(crate) share_price: String,
+    pub(crate) total_stake: String,
+    pub(crate) total_shares: String,
+    pub(crate) block_height: String,
+    pub(crate) block_time: DateTime<Utc>,
+}
+pub(crate) struct UpsertOperator {
+    pub(crate) operator_id: u64,
+    pub(crate) domain_id: u32,
+    pub(crate) owner_account: String,
+    pub(crate) signing_key: String,
+    pub(crate) minimum_nominator_stake: u128,
+    pub(crate) nomination_tax: u8,
+    pub(crate) status: String,
+    pub(crate) total_stake: u128,
+    pub(crate) total_shares: u128,
+    pub(crate) total_storage_fee_deposit: u128,
+    pub(crate) block_time: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow, Serialize)]
+pub(crate) struct OperatorRow {
+    pub(crate) operator_id: String,
+    pub(crate) domain_id: String,
+    pub(crate) owner_account: String,
+    pub(crate) signing_key: String,
+    pub(crate) minimum_nominator_stake: String,
+    pub(crate) nomination_tax: i16,
+    pub(crate) status: String,
+    pub(crate) total_stake: String,
+    pub(crate) total_shares: String,
+    pub(crate) total_storage_fee_deposit: String,
 }
 
 #[derive(Clone)]
@@ -425,15 +476,282 @@ impl Db {
 
         Ok(transfers)
     }
+
+    pub(crate) async fn upsert_epoch_share_price(&self, p: UpsertSharePrice) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO indexer.operator_epoch_share_prices
+                (operator_id, domain_id, epoch_index, share_price,
+                 total_stake, total_shares, block_height, block_time)
+            VALUES ($1, $2, $3, $4::numeric(28,18), $5::numeric(39,0), $6::numeric(39,0), $7, $8)
+            ON CONFLICT (operator_id, domain_id, epoch_index) DO UPDATE SET
+                share_price  = EXCLUDED.share_price,
+                total_stake  = EXCLUDED.total_stake,
+                total_shares = EXCLUDED.total_shares,
+                block_height = EXCLUDED.block_height,
+                block_time   = EXCLUDED.block_time
+            "#,
+        )
+        .bind(p.operator_id)
+        .bind(p.domain_id)
+        .bind(p.epoch_index)
+        .bind(p.share_price.to_string())
+        .bind(p.total_stake.to_string())
+        .bind(p.total_shares.to_string())
+        .bind(p.block_height)
+        .bind(p.block_time)
+        .execute(&*self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn upsert_nominator(
+        &self,
+        operator_id: u64,
+        address: &str,
+        status: &str,
+        block_height: u32,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO indexer.nominators (operator_id, address, status, block_height)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (operator_id, address) DO UPDATE
+                SET status = EXCLUDED.status,
+                    block_height = EXCLUDED.block_height
+                WHERE EXCLUDED.block_height >= indexer.nominators.block_height
+            "#,
+        )
+        .bind(operator_id as i64)
+        .bind(address)
+        .bind(status)
+        .bind(block_height as i64)
+        .execute(&*self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn get_share_prices_latest(
+        &self,
+        operator_id: i64,
+        limit: i64,
+    ) -> Result<Vec<SharePriceRow>, Error> {
+        let rows = sqlx::query_as::<_, SharePriceRow>(
+            r#"
+            SELECT operator_id::text, domain_id::text, epoch_index,
+                   share_price::text, total_stake::text, total_shares::text,
+                   block_height::text, block_time
+            FROM indexer.operator_epoch_share_prices
+            WHERE operator_id = $1
+            ORDER BY block_time DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(operator_id)
+        .bind(limit)
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub(crate) async fn get_share_prices_since(
+        &self,
+        operator_id: i64,
+        since: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<SharePriceRow>, Error> {
+        let rows = sqlx::query_as::<_, SharePriceRow>(
+            r#"
+            SELECT operator_id::text, domain_id::text, epoch_index,
+                   share_price::text, total_stake::text, total_shares::text,
+                   block_height::text, block_time
+            FROM indexer.operator_epoch_share_prices
+            WHERE operator_id = $1
+              AND block_time >= $2
+            ORDER BY block_time ASC
+            LIMIT $3
+            "#,
+        )
+        .bind(operator_id)
+        .bind(since)
+        .bind(limit)
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub(crate) async fn get_share_prices_until(
+        &self,
+        operator_id: i64,
+        until: DateTime<Utc>,
+        limit: i64,
+    ) -> Result<Vec<SharePriceRow>, Error> {
+        let rows = sqlx::query_as::<_, SharePriceRow>(
+            r#"
+            SELECT operator_id::text, domain_id::text, epoch_index,
+                   share_price::text, total_stake::text, total_shares::text,
+                   block_height::text, block_time
+            FROM indexer.operator_epoch_share_prices
+            WHERE operator_id = $1
+              AND block_time <= $2
+            ORDER BY block_time DESC
+            LIMIT $3
+            "#,
+        )
+        .bind(operator_id)
+        .bind(until)
+        .bind(limit)
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub(crate) async fn get_active_nominator_count(&self, operator_id: i64) -> Result<i64, Error> {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*)
+            FROM indexer.nominators
+            WHERE operator_id = $1
+              AND status = 'active'
+            "#,
+        )
+        .bind(operator_id)
+        .fetch_one(&*self.pool)
+        .await?;
+        Ok(count)
+    }
+    /// Upsert an operator row. On conflict only updates the mutable columns
+    /// (stake/shares/status/updated_at). Static columns (signing_key, etc.)
+    /// are preserved from the first insert.
+    pub(crate) async fn upsert_operator(&self, op: UpsertOperator) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO indexer.operators (
+                operator_id, domain_id, owner_account, signing_key,
+                minimum_nominator_stake, nomination_tax, status,
+                total_stake, total_shares, total_storage_fee_deposit, updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5::numeric(39,0), $6, $7,
+                    $8::numeric(39,0), $9::numeric(39,0), $10::numeric(39,0), $11)
+            ON CONFLICT (operator_id) DO UPDATE SET
+                status                    = EXCLUDED.status,
+                total_stake               = EXCLUDED.total_stake,
+                total_shares              = EXCLUDED.total_shares,
+                total_storage_fee_deposit = EXCLUDED.total_storage_fee_deposit,
+                updated_at                = EXCLUDED.updated_at
+            "#,
+        )
+        .bind(op.operator_id as i64)
+        .bind(op.domain_id as i32)
+        .bind(&op.owner_account)
+        .bind(&op.signing_key)
+        .bind(op.minimum_nominator_stake.to_string())
+        .bind(op.nomination_tax as i16)
+        .bind(&op.status)
+        .bind(op.total_stake.to_string())
+        .bind(op.total_shares.to_string())
+        .bind(op.total_storage_fee_deposit.to_string())
+        .bind(op.block_time)
+        .execute(&*self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn update_operator_status(
+        &self,
+        operator_id: u64,
+        status: &str,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            UPDATE indexer.operators
+            SET status = $2, updated_at = NOW()
+            WHERE operator_id = $1
+            "#,
+        )
+        .bind(operator_id as i64)
+        .bind(status)
+        .execute(&*self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn update_operator_stats(
+        &self,
+        operator_id: u64,
+        status: &str,
+        total_stake: u128,
+        total_shares: u128,
+        total_storage_fee_deposit: u128,
+        block_time: DateTime<Utc>,
+    ) -> Result<(), Error> {
+        sqlx::query(
+            r#"
+            UPDATE indexer.operators
+            SET status                    = $2,
+                total_stake               = $3::numeric(39,0),
+                total_shares              = $4::numeric(39,0),
+                total_storage_fee_deposit = $5::numeric(39,0),
+                updated_at                = $6
+            WHERE operator_id = $1
+            "#,
+        )
+        .bind(operator_id as i64)
+        .bind(status)
+        .bind(total_stake.to_string())
+        .bind(total_shares.to_string())
+        .bind(total_storage_fee_deposit.to_string())
+        .bind(block_time)
+        .execute(&*self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn get_all_operators(&self) -> Result<Vec<OperatorRow>, Error> {
+        let rows = sqlx::query_as::<_, OperatorRow>(
+            r#"
+            SELECT operator_id::text, domain_id::text, owner_account,
+                   signing_key, minimum_nominator_stake::text, nomination_tax,
+                   status, total_stake::text, total_shares::text,
+                   total_storage_fee_deposit::text
+            FROM indexer.operators
+            ORDER BY operators.operator_id ASC
+            "#,
+        )
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub(crate) async fn get_operator(
+        &self,
+        operator_id: i64,
+    ) -> Result<Option<OperatorRow>, Error> {
+        let row = sqlx::query_as::<_, OperatorRow>(
+            r#"
+            SELECT operator_id::text, domain_id::text, owner_account,
+                   signing_key, minimum_nominator_stake::text, nomination_tax,
+                   status, total_stake::text, total_shares::text,
+                   total_storage_fee_deposit::text
+            FROM indexer.operators
+            WHERE operator_id = $1
+            "#,
+        )
+        .bind(operator_id)
+        .fetch_optional(&*self.pool)
+        .await?;
+        Ok(row)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::Db;
+    use crate::storage::{Db, UpsertOperator, UpsertSharePrice};
     use crate::types::{ChainId, DomainId};
     use crate::xdm::extract_xdm_events_for_block;
-    use chrono::DateTime;
+    use chrono::{DateTime, Utc};
     use pgtemp::{PgTempDB, PgTempDBBuilder};
+    use rust_decimal::Decimal;
     use shared::subspace::{HashAndNumber, Subspace};
     use sp_core::crypto::{Ss58AddressFormat, set_default_ss58_version};
     use std::str::FromStr;
@@ -456,6 +774,40 @@ mod tests {
         TestDb {
             db,
             _temp_db: temp_db,
+        }
+    }
+
+    fn sample_operator(operator_id: u64) -> UpsertOperator {
+        UpsertOperator {
+            operator_id,
+            domain_id: 0,
+            owner_account: format!("owner_{operator_id}"),
+            signing_key: format!("0xsigning_key_{operator_id}"),
+            minimum_nominator_stake: 1_000_000_000_000_000_000,
+            nomination_tax: 5,
+            status: "registered".to_string(),
+            total_stake: 50_000_000_000_000_000_000,
+            total_shares: 50_000_000_000_000_000_000,
+            total_storage_fee_deposit: 1_000_000_000_000_000_000,
+            block_time: DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
+        }
+    }
+
+    fn sample_share_price(
+        operator_id: i64,
+        epoch_index: i64,
+        block_height: i64,
+    ) -> UpsertSharePrice {
+        UpsertSharePrice {
+            operator_id,
+            domain_id: 0,
+            epoch_index,
+            share_price: Decimal::new(1_000_000_000_000_000_000, 18), // 1.0
+            total_stake: 50_000_000_000_000_000_000,
+            total_shares: 50_000_000_000_000_000_000,
+            block_height,
+            block_time: DateTime::from_timestamp_millis(1_700_000_000_000 + epoch_index * 60_000)
+                .unwrap(),
         }
     }
 
@@ -651,5 +1003,289 @@ mod tests {
             .store_events(&ChainId::Domain(DomainId(0)), block, block_time, events)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_upsert_operator_insert_and_update() {
+        let db = get_db().await;
+        let op = sample_operator(1);
+        db.db.upsert_operator(op).await.unwrap();
+
+        let row = db.db.get_operator(1).await.unwrap().unwrap();
+        assert_eq!(row.operator_id, "1");
+        assert_eq!(row.domain_id, "0");
+        assert_eq!(row.signing_key, "0xsigning_key_1");
+        assert_eq!(row.status, "registered");
+        assert_eq!(row.nomination_tax, 5);
+
+        // Re-upsert with updated stats — static fields (signing_key, etc.) should be preserved
+        let mut op2 = sample_operator(1);
+        op2.total_stake = 100_000_000_000_000_000_000;
+        op2.status = "deregistered".to_string();
+        db.db.upsert_operator(op2).await.unwrap();
+
+        let row = db.db.get_operator(1).await.unwrap().unwrap();
+        assert_eq!(row.status, "deregistered");
+        assert_eq!(row.total_stake, "100000000000000000000");
+        // signing_key preserved from original insert
+        assert_eq!(row.signing_key, "0xsigning_key_1");
+    }
+
+    #[tokio::test]
+    async fn test_update_operator_status() {
+        let db = get_db().await;
+        db.db.upsert_operator(sample_operator(2)).await.unwrap();
+
+        db.db
+            .update_operator_status(2, "deregistered")
+            .await
+            .unwrap();
+        let row = db.db.get_operator(2).await.unwrap().unwrap();
+        assert_eq!(row.status, "deregistered");
+
+        db.db.update_operator_status(2, "registered").await.unwrap();
+        let row = db.db.get_operator(2).await.unwrap().unwrap();
+        assert_eq!(row.status, "registered");
+    }
+
+    #[tokio::test]
+    async fn test_update_operator_stats() {
+        let db = get_db().await;
+        db.db.upsert_operator(sample_operator(3)).await.unwrap();
+
+        let new_time = DateTime::from_timestamp_millis(1_700_001_000_000).unwrap();
+        db.db
+            .update_operator_stats(3, "registered", 999, 888, 777, new_time)
+            .await
+            .unwrap();
+
+        let row = db.db.get_operator(3).await.unwrap().unwrap();
+        assert_eq!(row.total_stake, "999");
+        assert_eq!(row.total_shares, "888");
+        assert_eq!(row.total_storage_fee_deposit, "777");
+    }
+
+    #[tokio::test]
+    async fn test_update_operator_stats_noop_for_missing_operator() {
+        let db = get_db().await;
+        // No operator 99 exists — update_operator_stats should be a silent no-op
+        let result = db
+            .db
+            .update_operator_stats(
+                99,
+                "registered",
+                1,
+                1,
+                1,
+                DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
+            )
+            .await;
+        assert!(result.is_ok());
+        assert!(db.db.get_operator(99).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_all_operators_sorted() {
+        let db = get_db().await;
+        // Insert operators out of order
+        db.db.upsert_operator(sample_operator(5)).await.unwrap();
+        db.db.upsert_operator(sample_operator(2)).await.unwrap();
+        db.db.upsert_operator(sample_operator(10)).await.unwrap();
+
+        let all = db.db.get_all_operators().await.unwrap();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].operator_id, "2");
+        assert_eq!(all[1].operator_id, "5");
+        assert_eq!(all[2].operator_id, "10");
+    }
+
+    #[tokio::test]
+    async fn test_get_operator_not_found() {
+        let db = get_db().await;
+        let result = db.db.get_operator(999).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_upsert_nominator_block_height_guard() {
+        let db = get_db().await;
+        let addr = "st1234567890abcdef";
+
+        // Block 10: nominator is active
+        db.db.upsert_nominator(1, addr, "active", 10).await.unwrap();
+        let count = db.db.get_active_nominator_count(1).await.unwrap();
+        assert_eq!(count, 1);
+
+        // Block 5 (older): withdrawal arrives out-of-order via buffered parallelism
+        // This should NOT overwrite the block-10 "active" status
+        db.db
+            .upsert_nominator(1, addr, "withdrawn", 5)
+            .await
+            .unwrap();
+        let count = db.db.get_active_nominator_count(1).await.unwrap();
+        assert_eq!(count, 1, "older block should not overwrite newer status");
+
+        // Block 15 (newer): withdrawal is legitimate
+        db.db
+            .upsert_nominator(1, addr, "withdrawn", 15)
+            .await
+            .unwrap();
+        let count = db.db.get_active_nominator_count(1).await.unwrap();
+        assert_eq!(count, 0, "newer block should update status to withdrawn");
+    }
+
+    #[tokio::test]
+    async fn test_upsert_nominator_same_block_overwrites() {
+        let db = get_db().await;
+        let addr = "st_same_block";
+
+        // Same block height: the later write wins (>= guard allows it)
+        db.db.upsert_nominator(1, addr, "active", 10).await.unwrap();
+        db.db
+            .upsert_nominator(1, addr, "withdrawn", 10)
+            .await
+            .unwrap();
+        let count = db.db.get_active_nominator_count(1).await.unwrap();
+        assert_eq!(count, 0, "same-block write should update");
+    }
+
+    #[tokio::test]
+    async fn test_get_active_nominator_count_multiple_operators() {
+        let db = get_db().await;
+
+        // Operator 1: 2 active, 1 withdrawn
+        db.db
+            .upsert_nominator(1, "addr_a", "active", 10)
+            .await
+            .unwrap();
+        db.db
+            .upsert_nominator(1, "addr_b", "active", 10)
+            .await
+            .unwrap();
+        db.db
+            .upsert_nominator(1, "addr_c", "withdrawn", 10)
+            .await
+            .unwrap();
+
+        // Operator 2: 1 active
+        db.db
+            .upsert_nominator(2, "addr_a", "active", 10)
+            .await
+            .unwrap();
+
+        assert_eq!(db.db.get_active_nominator_count(1).await.unwrap(), 2);
+        assert_eq!(db.db.get_active_nominator_count(2).await.unwrap(), 1);
+        assert_eq!(db.db.get_active_nominator_count(99).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_epoch_share_price_overwrites_on_reorg() {
+        let db = get_db().await;
+
+        // First write for operator 1, epoch 5
+        let sp = sample_share_price(1, 5, 1000);
+        db.db.upsert_epoch_share_price(sp).await.unwrap();
+
+        let rows = db.db.get_share_prices_latest(1, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].total_stake, "50000000000000000000");
+
+        // Re-org: same (operator, domain, epoch) but different data
+        let mut sp2 = sample_share_price(1, 5, 1001);
+        sp2.total_stake = 99_000_000_000_000_000_000;
+        sp2.share_price = Decimal::new(1_050_000_000_000_000_000, 18); // 1.05
+        db.db.upsert_epoch_share_price(sp2).await.unwrap();
+
+        let rows = db.db.get_share_prices_latest(1, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].total_stake, "99000000000000000000",
+            "re-org should overwrite"
+        );
+        assert_eq!(rows[0].block_height, "1001");
+    }
+
+    #[tokio::test]
+    async fn test_get_share_prices_latest_with_limit() {
+        let db = get_db().await;
+
+        // Insert 5 epochs for operator 1
+        for epoch in 1..=5 {
+            let sp = sample_share_price(1, epoch, epoch * 100);
+            db.db.upsert_epoch_share_price(sp).await.unwrap();
+        }
+
+        // Query latest 3
+        let rows = db.db.get_share_prices_latest(1, 3).await.unwrap();
+        assert_eq!(rows.len(), 3);
+        // Ordered DESC by block_time → epochs 5, 4, 3
+        assert_eq!(rows[0].epoch_index, 5);
+        assert_eq!(rows[1].epoch_index, 4);
+        assert_eq!(rows[2].epoch_index, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_share_prices_since() {
+        let db = get_db().await;
+
+        for epoch in 1..=5 {
+            let sp = sample_share_price(1, epoch, epoch * 100);
+            db.db.upsert_epoch_share_price(sp).await.unwrap();
+        }
+
+        // `since` the time of epoch 3 (base + 3 * 60s)
+        let since: DateTime<Utc> =
+            DateTime::from_timestamp_millis(1_700_000_000_000 + 3 * 60_000).unwrap();
+        let rows = db.db.get_share_prices_since(1, since, 50).await.unwrap();
+        // Should return epochs 3, 4, 5 (ascending)
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].epoch_index, 3);
+        assert_eq!(rows[1].epoch_index, 4);
+        assert_eq!(rows[2].epoch_index, 5);
+    }
+
+    #[tokio::test]
+    async fn test_get_share_prices_until() {
+        let db = get_db().await;
+
+        for epoch in 1..=5 {
+            let sp = sample_share_price(1, epoch, epoch * 100);
+            db.db.upsert_epoch_share_price(sp).await.unwrap();
+        }
+
+        // `until` the time of epoch 3
+        let until: DateTime<Utc> =
+            DateTime::from_timestamp_millis(1_700_000_000_000 + 3 * 60_000).unwrap();
+        let rows = db.db.get_share_prices_until(1, until, 50).await.unwrap();
+        // Should return epochs 3, 2, 1 (descending)
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].epoch_index, 3);
+        assert_eq!(rows[1].epoch_index, 2);
+        assert_eq!(rows[2].epoch_index, 1);
+    }
+
+    #[tokio::test]
+    async fn test_share_prices_different_operators_isolated() {
+        let db = get_db().await;
+
+        db.db
+            .upsert_epoch_share_price(sample_share_price(1, 1, 100))
+            .await
+            .unwrap();
+        db.db
+            .upsert_epoch_share_price(sample_share_price(1, 2, 200))
+            .await
+            .unwrap();
+        db.db
+            .upsert_epoch_share_price(sample_share_price(2, 1, 100))
+            .await
+            .unwrap();
+
+        assert_eq!(db.db.get_share_prices_latest(1, 50).await.unwrap().len(), 2);
+        assert_eq!(db.db.get_share_prices_latest(2, 50).await.unwrap().len(), 1);
+        assert_eq!(
+            db.db.get_share_prices_latest(99, 50).await.unwrap().len(),
+            0
+        );
     }
 }

--- a/indexer/src/types.rs
+++ b/indexer/src/types.rs
@@ -7,8 +7,8 @@ use shared::subspace::Balance;
 use sqlx::error::BoxDynError;
 use sqlx::postgres::{PgTypeInfo, PgValueRef};
 use sqlx::{Decode as SqlxDecode, Postgres, Type};
+use std::collections::BTreeMap;
 use std::fmt::{Debug, Display, Formatter};
-use subxt::events::StaticEvent;
 use subxt::utils::{AccountId32, H160, to_hex};
 
 #[derive(Serialize, Deserialize, Default, PartialEq, Debug, Copy, Clone)]
@@ -85,71 +85,6 @@ pub(crate) type XdmChannelId = U256Compat;
 pub(crate) type XdmNonce = U256Compat;
 pub(crate) type XdmMessageId = (XdmChannelId, XdmNonce);
 
-#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
-pub(crate) struct OutgoingTransferInitiated {
-    pub(crate) chain_id: ChainId,
-    pub(crate) message_id: XdmMessageId,
-    pub(crate) amount: Balance,
-}
-
-impl StaticEvent for OutgoingTransferInitiated {
-    const PALLET: &'static str = "Transporter";
-    const EVENT: &'static str = "OutgoingTransferInitiated";
-}
-
-#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
-pub(crate) struct OutgoingTransferFailed {
-    pub(crate) chain_id: ChainId,
-    pub(crate) message_id: XdmMessageId,
-    // TODO: capture error as well
-}
-
-impl StaticEvent for OutgoingTransferFailed {
-    const PALLET: &'static str = "Transporter";
-    const EVENT: &'static str = "OutgoingTransferFailed";
-}
-
-impl From<OutgoingTransferFailed> for Event {
-    fn from(value: OutgoingTransferFailed) -> Self {
-        Event::OutgoingTransferFailed(value)
-    }
-}
-
-#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
-pub(crate) struct OutgoingTransferSuccessful {
-    pub(crate) chain_id: ChainId,
-    pub(crate) message_id: XdmMessageId,
-}
-
-impl StaticEvent for OutgoingTransferSuccessful {
-    const PALLET: &'static str = "Transporter";
-    const EVENT: &'static str = "OutgoingTransferSuccessful";
-}
-
-impl From<OutgoingTransferSuccessful> for Event {
-    fn from(value: OutgoingTransferSuccessful) -> Self {
-        Event::OutgoingTransferSuccessful(value)
-    }
-}
-
-#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
-pub(crate) struct IncomingTransferSuccessful {
-    pub(crate) chain_id: ChainId,
-    pub(crate) message_id: XdmMessageId,
-    pub(crate) amount: Balance,
-}
-
-impl StaticEvent for IncomingTransferSuccessful {
-    const PALLET: &'static str = "Transporter";
-    const EVENT: &'static str = "IncomingTransferSuccessful";
-}
-
-impl From<IncomingTransferSuccessful> for Event {
-    fn from(value: IncomingTransferSuccessful) -> Self {
-        Event::IncomingTransferSuccessful(value)
-    }
-}
-
 #[derive(Debug, Clone, DecodeAsType, Decode, Eq, PartialEq)]
 pub(crate) enum MultiAccountId {
     /// 32 byte account Id.
@@ -193,23 +128,28 @@ pub(crate) struct Transfer {
     pub receiver: Location,
 }
 
-#[derive(Debug, Clone, DecodeAsType, Eq, PartialEq)]
-pub(crate) struct OutgoingTransferInitiatedWithTransfer {
-    pub(crate) message_id: XdmMessageId,
-    pub(crate) transfer: Transfer,
+/// Mirrors `pallet_domains::staking::DomainEpoch(DomainId, EpochIndex)`.
+/// Used as the second key of the `OperatorEpochSharePrice` storage double-map.
+/// Both EncodeAsType and DecodeAsType are required by StaticStorageKey<T>.
+#[derive(Debug, Clone, DecodeAsType, EncodeAsType, Eq, PartialEq)]
+pub(crate) struct DomainEpoch(pub(crate) DomainId, pub(crate) u32);
+
+/// Partial decode of `pallet_domains::staking::StakingSummary`.
+/// Only `current_operators` is needed; the preceding fields are read-and-discarded
+/// and the remaining fields (`next_operators`, `current_epoch_rewards`) are left in
+/// the input — SCALE Decode does not require consuming all bytes.
+#[derive(Debug)]
+pub(crate) struct StakingSummary {
+    pub(crate) current_operators: BTreeMap<u64, u128>,
 }
 
-impl From<OutgoingTransferInitiatedWithTransfer> for Event {
-    fn from(value: OutgoingTransferInitiatedWithTransfer) -> Self {
-        Event::OutgoingTransferInitiated(value)
+impl Decode for StakingSummary {
+    fn decode<I: parity_scale_codec::Input>(
+        input: &mut I,
+    ) -> Result<Self, parity_scale_codec::Error> {
+        let _ = u32::decode(input)?; // current_epoch_index
+        let _ = u128::decode(input)?; // current_total_stake
+        let current_operators = BTreeMap::<u64, u128>::decode(input)?;
+        Ok(Self { current_operators })
     }
-}
-
-/// Overarching event type
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) enum Event {
-    OutgoingTransferInitiated(OutgoingTransferInitiatedWithTransfer),
-    OutgoingTransferFailed(OutgoingTransferFailed),
-    OutgoingTransferSuccessful(OutgoingTransferSuccessful),
-    IncomingTransferSuccessful(IncomingTransferSuccessful),
 }

--- a/indexer/src/xdm.rs
+++ b/indexer/src/xdm.rs
@@ -1,10 +1,11 @@
 use crate::error::Error;
-use crate::storage::Db;
-use crate::types::{
-    ChainId, DomainId, Event, IncomingTransferSuccessful, OutgoingTransferFailed,
-    OutgoingTransferInitiated, OutgoingTransferInitiatedWithTransfer, OutgoingTransferSuccessful,
-    Transfer,
+use crate::events::{
+    Event, IncomingTransferSuccessful, OutgoingTransferFailed, OutgoingTransferInitiated,
+    OutgoingTransferInitiatedWithTransfer, OutgoingTransferSuccessful,
 };
+use crate::processor::{self, BlockProcessor};
+use crate::storage::Db;
+use crate::types::{ChainId, DomainId, Transfer};
 use futures_util::{StreamExt, TryStreamExt, stream};
 use shared::subspace::{BlockExt, BlockNumber, BlocksStream, HashAndNumber, SubspaceBlockProvider};
 use sqlx::types::chrono::DateTime;
@@ -13,83 +14,59 @@ use subxt::events::{EventDetails, StaticEvent};
 use subxt::storage::StaticStorageKey;
 use tracing::info;
 
-const CHECKPOINT_PROCESSED_BLOCK: u32 = 100;
-
-pub(crate) fn get_processor_key(chain_id: &ChainId) -> String {
+pub(crate) fn get_xdm_processor_key(chain_id: &ChainId) -> String {
     format!("xdm_processor_{chain_id}")
+}
+
+pub(crate) struct XdmProcessor {
+    chain: ChainId,
+    checkpoint_key: String,
+}
+
+impl XdmProcessor {
+    pub(crate) fn new(chain: ChainId) -> Self {
+        let checkpoint_key = get_xdm_processor_key(&chain);
+        Self {
+            chain,
+            checkpoint_key,
+        }
+    }
+}
+
+impl BlockProcessor for XdmProcessor {
+    async fn process_block(
+        &self,
+        block_number: BlockNumber,
+        db: &Db,
+        block_provider: &SubspaceBlockProvider,
+    ) -> Result<(), Error> {
+        index_events_for_block(&self.chain, block_number, db, block_provider).await
+    }
+
+    fn checkpoint_key(&self) -> &str {
+        &self.checkpoint_key
+    }
+
+    fn name(&self) -> &str {
+        "XDM"
+    }
 }
 
 pub(crate) async fn index_xdm(
     chain: ChainId,
-    mut stream: BlocksStream,
+    stream: BlocksStream,
     block_provider: SubspaceBlockProvider,
     db: Db,
     process_blocks_in_parallel: u32,
 ) -> Result<(), Error> {
-    let processor_key = get_processor_key(&chain);
-    loop {
-        let blocks_ext = stream.recv().await?;
-        let last_processed_block_number = db
-            .get_last_processed_block(&processor_key)
-            .await
-            .unwrap_or(0);
-
-        // if there is only one imported block, then
-        // chain extended by one block, so index from last_processed + 1 ..=new_block
-        let (from, to) = if blocks_ext.blocks.len() == 1 {
-            (
-                last_processed_block_number + 1,
-                blocks_ext
-                    .blocks
-                    .first()
-                    .expect("must contain at least one block")
-                    .number,
-            )
-        } else {
-            let blocks = blocks_ext
-                .blocks
-                .iter()
-                .map(|b| b.number)
-                .collect::<Vec<_>>();
-            let min = *blocks
-                .iter()
-                .min()
-                .expect("should have more than one block");
-            let max = *blocks
-                .iter()
-                .max()
-                .expect("should have more than one block");
-
-            (min.min(last_processed_block_number + 1), max)
-        };
-
-        if from > to {
-            continue;
-        }
-
-        info!("Indexing blocks from[{from}] to to[{to}]...");
-        let mut s = stream::iter((from..=to).map(|block| {
-            let chain = &chain;
-            let db = &db;
-            let block_provider = &block_provider;
-            async move {
-                index_events_for_block(chain, block, db, block_provider)
-                    .await
-                    .map(|_| block)
-            }
-        }))
-        .buffered(process_blocks_in_parallel as usize);
-
-        while let Some(block) = s.try_next().await? {
-            if block.is_multiple_of(CHECKPOINT_PROCESSED_BLOCK) {
-                info!("Indexed block: {}", block);
-                db.set_last_processed_block(&processor_key, block).await?;
-            }
-        }
-
-        info!("Indexed block: {}", to);
-        db.set_last_processed_block(&processor_key, to).await?;
-    }
+    processor::run_processor(
+        XdmProcessor::new(chain),
+        stream,
+        block_provider,
+        db,
+        process_blocks_in_parallel,
+    )
+    .await
 }
 
 async fn index_events_for_block(
@@ -176,11 +153,11 @@ fn as_events<E: StaticEvent + Into<Event>>(
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{
-        ChainId, DomainId, Event, IncomingTransferSuccessful, Location, MultiAccountId,
-        OutgoingTransferFailed, OutgoingTransferInitiatedWithTransfer, OutgoingTransferSuccessful,
-        Transfer,
+    use crate::events::{
+        Event, IncomingTransferSuccessful, OutgoingTransferFailed,
+        OutgoingTransferInitiatedWithTransfer, OutgoingTransferSuccessful,
     };
+    use crate::types::{ChainId, DomainId, Location, MultiAccountId, Transfer};
     use crate::xdm::extract_xdm_events_for_block;
     use hex_literal::hex;
     use scale_decode::ext::primitive_types::U256;

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -6,8 +6,6 @@ use subxt::utils::H256;
 pub enum Error {
     #[error("Subxt error: {0}")]
     Subxt(Box<subxt::Error>),
-    #[error("Block missing from backend")]
-    MissingBlock,
     #[error("Block subscription closed")]
     SubscriptionClosed,
     #[error("RPC error: {0}")]

--- a/shared/src/subspace.rs
+++ b/shared/src/subspace.rs
@@ -59,6 +59,15 @@ impl SubspaceBlockProvider {
         self.block_ext_at_hash(block_hash).await
     }
 
+    pub async fn block_ext_latest(&self) -> Result<BlockExt, Error> {
+        let hash = self
+            .rpc
+            .chain_get_block_hash(None)
+            .await?
+            .ok_or(Error::MissingBlockHeaderForNumber(0))?;
+        self.block_ext_at_hash(hash).await
+    }
+
     pub async fn block_ext_at_hash(&self, block_hash: BlockHash) -> Result<BlockExt, Error> {
         let header = self
             .rpc
@@ -110,6 +119,27 @@ impl BlockExt {
             .await?
             .map(|encoded| T::decode(&mut encoded.encoded()).map_err(Error::Scale))
             .ok_or(Error::Storage(format!("{pallet}.{storage}")))?
+    }
+
+    /// Iterates all entries in a storage map, returning `(raw_key_bytes, decoded_value)` pairs.
+    ///
+    /// For a map with `Identity` hasher the operator ID is the last 8 bytes of the key.
+    pub async fn iter_storage<T: Decode>(
+        &self,
+        pallet: &str,
+        storage: &str,
+    ) -> Result<Vec<(Vec<u8>, T)>, Error> {
+        use subxt::dynamic::Value;
+        let query = subxt::dynamic::storage(pallet, storage, Vec::<Value>::new());
+        let mut stream = self.client.storage().at(self.hash).iter(query).await?;
+        let mut items = Vec::new();
+        while let Some(kv) = stream.next().await {
+            let kv = kv?;
+            let encoded = kv.value.encoded();
+            let value = T::decode(&mut &encoded[..]).map_err(Error::Scale)?;
+            items.push((kv.key_bytes, value));
+        }
+        Ok(items)
     }
 
     /// Returns block timestamp.
@@ -305,12 +335,19 @@ impl Subspace {
             error!("Block subscription closed: {res:?}");
             // if disconnected or subscription ended, reinitiate for reconnection
             match &res {
-                Err(Error::Rpc(_)) => {
+                Err(Error::Subxt(_)) | Err(Error::Rpc(_)) => {
                     warn!("RPC connection disconnected. Reinitiating...");
                     continue;
                 }
                 Err(Error::SubscriptionClosed) => {
                     warn!("Block subscription closed. Reinitiating...");
+                    continue;
+                }
+                // we reconnect if there was a missing block.
+                // could be due to client has not indexed the details yet.
+                Err(Error::MissingBlockHeaderForNumber(_))
+                | Err(Error::MissingBlockHeaderForHash(_)) => {
+                    warn!("Missing block data. Reinitiating...");
                     continue;
                 }
                 _ => return res,
@@ -411,7 +448,7 @@ impl Subspace {
             .rpc
             .chain_get_block_hash(Some(block_number.into()))
             .await?
-            .ok_or(Error::MissingBlock)?;
+            .ok_or(Error::MissingBlockHeaderForNumber(block_number))?;
         Ok(block_hash == hash)
     }
 
@@ -459,7 +496,7 @@ impl Subspace {
             .rpc
             .chain_get_header(Some(latest_hash))
             .await?
-            .ok_or(Error::MissingBlock)?;
+            .ok_or(Error::MissingBlockHeaderForHash(latest_hash))?;
 
         let cache_start_number = latest_head.number.saturating_sub(CACHE_HEADER_DEPTH);
 
@@ -474,12 +511,12 @@ impl Subspace {
                     .rpc
                     .chain_get_block_hash(Some(number.into()))
                     .await?
-                    .ok_or(Error::MissingBlock)?;
+                    .ok_or(Error::MissingBlockHeaderForNumber(number))?;
                 let header = self
                     .rpc
                     .chain_get_header(Some(block_hash))
                     .await?
-                    .ok_or(Error::MissingBlock)?;
+                    .ok_or(Error::MissingBlockHeaderForHash(block_hash))?;
                 debug!("Block header from RPC {number} - {block_hash}");
                 Ok::<_, Error>(header)
             }),
@@ -513,7 +550,7 @@ impl Subspace {
                         .rpc
                         .chain_get_header(Some(hash))
                         .await?
-                        .ok_or(Error::MissingBlock)?;
+                        .ok_or(Error::MissingBlockHeaderForHash(hash))?;
                     header_metadata.add_header(header);
                     Box::pin(self.recursive_tree_route(header_metadata, from, to)).await
                 }


### PR DESCRIPTION
Add complete staking module that indexes operator registrations, nominations, withdrawals, slashing, and epoch transitions from consensus chain events. Includes share price history, nominator counting, and REST API endpoints.

- Add staking event decoder and block processor
- Add operator/nominator/share-price DB schema and queries
- Add API endpoints: operators, share prices, nominator counts
- Fix DecodeAsType bug: remove _domain_id fields from event structs
- Add owner_account to operator API response
- Return 404 (not 500) for missing operators
- Add RPC-based integration tests for all staking events