### PR TITLE
chore: add warn logging to silent errors, extract shared test utilities

### DIFF
--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -11,6 +11,9 @@ mod storage;
 mod types;
 mod xdm;
 
+#[cfg(test)]
+mod test_utils;
+
 use crate::error::Error;
 use crate::storage::{Db, log_db_pool_info};
 use crate::types::{ChainId, DomainId};

--- a/indexer/src/rpc_types.rs
+++ b/indexer/src/rpc_types.rs
@@ -17,13 +17,12 @@ impl DomainEpochHelper {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) enum OperatorStatusCompact {
     Registered,
     Deregistered,
     Slashed,
     PendingSlash,
-    InvalidBundle([u8; 32]),
+    InvalidBundle,
     Deactivated,
 }
 
@@ -34,7 +33,7 @@ impl OperatorStatusCompact {
             Self::Deregistered => "deregistered",
             Self::Slashed => "slashed",
             Self::PendingSlash => "pending_slash",
-            Self::InvalidBundle(_) => "invalid_bundle",
+            Self::InvalidBundle => "invalid_bundle",
             Self::Deactivated => "deactivated",
         }
     }
@@ -56,8 +55,8 @@ impl Decode for OperatorStatusCompact {
             2 => Ok(Self::Slashed),
             3 => Ok(Self::PendingSlash),
             4 => {
-                let hash = <[u8; 32] as Decode>::decode(input)?;
-                Ok(Self::InvalidBundle(hash))
+                let _ = <[u8; 32] as Decode>::decode(input)?; // bad_receipt_hash
+                Ok(Self::InvalidBundle)
             }
             5 => {
                 let _ = u32::decode(input)?; // at_epoch_index

--- a/indexer/src/staking.rs
+++ b/indexer/src/staking.rs
@@ -69,7 +69,10 @@ async fn index_staking_for_block(
             .await
         {
             Ok(op) => op,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(operator_id = e.operator_id, %err, "failed to read Operators storage");
+                continue;
+            }
         };
         let owner: SubxtAccountId32 = match block_ext
             .read_storage(
@@ -80,7 +83,10 @@ async fn index_staking_for_block(
             .await
         {
             Ok(owner) => owner,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(operator_id = e.operator_id, %err, "failed to read OperatorIdOwner storage");
+                continue;
+            }
         };
         let owner_account = sp_core::crypto::AccountId32::new(owner.0).to_string();
         let signing_key_hex = format!("0x{}", hex::encode(op.signing_key));
@@ -187,7 +193,10 @@ async fn index_epoch_share_prices(
             .await
         {
             Ok(price) => price,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(%operator_id, %err, "failed to read OperatorEpochSharePrice");
+                continue;
+            }
         };
 
         // Read full operator data for stake/shares/status/storage-fee.
@@ -196,7 +205,10 @@ async fn index_epoch_share_prices(
             .await
         {
             Ok(op) => op,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(%operator_id, %err, "failed to read Operators storage for share price update");
+                continue;
+            }
         };
 
         // Convert Perquintill to decimal: raw_u64 / 10^18
@@ -239,8 +251,7 @@ mod tests {
         DomainEpochCompleted, OperatorNominated, OperatorRegistered, WithdrewStake,
     };
     use crate::rpc_types::FullOperator;
-    use crate::storage::{Db, UpsertOperator};
-    use pgtemp::{PgTempDB, PgTempDBBuilder};
+    use crate::test_utils::{get_db, sample_operator};
     use shared::subspace::Subspace;
     use std::str::FromStr;
     use subxt::storage::StaticStorageKey;
@@ -257,40 +268,6 @@ mod tests {
         "0xe70e7da10ae1fa68f5e274e6f673ae6933386e688284186dec88fc2870f38e24";
     const OPERATOR_NOMINATED_HASH: &str =
         "0x5df7664c6e14422fdbbc68f5d78f4252e2151bce887b9659e4eea53df59e3f74";
-
-    struct TestDb {
-        db: Db,
-        _temp_db: PgTempDB,
-    }
-
-    async fn get_db() -> TestDb {
-        let temp_db = PgTempDBBuilder::new().start_async().await;
-        let db = Db::new(temp_db.connection_uri().as_str(), "./migrations")
-            .await
-            .unwrap();
-        TestDb {
-            db,
-            _temp_db: temp_db,
-        }
-    }
-
-    fn sample_operator(operator_id: u64) -> UpsertOperator {
-        UpsertOperator {
-            operator_id,
-            domain_id: 0,
-            owner_account: format!("owner_{operator_id}"),
-            signing_key: format!("0xsigning_key_{operator_id}"),
-            minimum_nominator_stake: 1_000_000_000_000_000_000,
-            nomination_tax: 5,
-            status: "registered".to_string(),
-            total_stake: 50_000_000_000_000_000_000,
-            total_shares: 50_000_000_000_000_000_000,
-            total_storage_fee_deposit: 1_000_000_000_000_000_000,
-            block_time: chrono::DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
-        }
-    }
-
-    // ── Event-only decode tests (RPC, no DB) ─────────────────────────
 
     #[tokio::test]
     async fn test_decode_operator_registered() {
@@ -403,8 +380,6 @@ mod tests {
         let e = &completed[0];
         assert!(e.completed_epoch_index > 0, "epoch index should be > 0");
     }
-
-    // ── End-to-end tests (RPC + pgtemp DB) ───────────────────────────
 
     #[tokio::test]
     async fn test_index_staking_operator_registered() {

--- a/indexer/src/storage.rs
+++ b/indexer/src/storage.rs
@@ -746,70 +746,15 @@ impl Db {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::{Db, UpsertOperator, UpsertSharePrice};
+    use crate::test_utils::{get_db, sample_operator, sample_share_price};
     use crate::types::{ChainId, DomainId};
     use crate::xdm::extract_xdm_events_for_block;
     use chrono::{DateTime, Utc};
-    use pgtemp::{PgTempDB, PgTempDBBuilder};
     use rust_decimal::Decimal;
     use shared::subspace::{HashAndNumber, Subspace};
     use sp_core::crypto::{Ss58AddressFormat, set_default_ss58_version};
     use std::str::FromStr;
     use subxt::utils::H256;
-
-    struct TestDb {
-        db: Db,
-        // used to hold the temp_db in context
-        // else temp db is dropped and db timeouts since there
-        // is no running postgres service underneath
-        _temp_db: PgTempDB,
-    }
-
-    async fn get_db() -> TestDb {
-        let temp_db = PgTempDBBuilder::new().start_async().await;
-        let db = Db::new(temp_db.connection_uri().as_str(), "./migrations")
-            .await
-            .unwrap();
-
-        TestDb {
-            db,
-            _temp_db: temp_db,
-        }
-    }
-
-    fn sample_operator(operator_id: u64) -> UpsertOperator {
-        UpsertOperator {
-            operator_id,
-            domain_id: 0,
-            owner_account: format!("owner_{operator_id}"),
-            signing_key: format!("0xsigning_key_{operator_id}"),
-            minimum_nominator_stake: 1_000_000_000_000_000_000,
-            nomination_tax: 5,
-            status: "registered".to_string(),
-            total_stake: 50_000_000_000_000_000_000,
-            total_shares: 50_000_000_000_000_000_000,
-            total_storage_fee_deposit: 1_000_000_000_000_000_000,
-            block_time: DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
-        }
-    }
-
-    fn sample_share_price(
-        operator_id: i64,
-        epoch_index: i64,
-        block_height: i64,
-    ) -> UpsertSharePrice {
-        UpsertSharePrice {
-            operator_id,
-            domain_id: 0,
-            epoch_index,
-            share_price: Decimal::new(1_000_000_000_000_000_000, 18), // 1.0
-            total_stake: 50_000_000_000_000_000_000,
-            total_shares: 50_000_000_000_000_000_000,
-            block_height,
-            block_time: DateTime::from_timestamp_millis(1_700_000_000_000 + epoch_index * 60_000)
-                .unwrap(),
-        }
-    }
 
     #[tokio::test]
     async fn test_store_last_processed_block() {

--- a/indexer/src/test_utils.rs
+++ b/indexer/src/test_utils.rs
@@ -1,0 +1,57 @@
+//! Shared test utilities for integration tests across modules.
+
+use crate::storage::{Db, UpsertOperator, UpsertSharePrice};
+use chrono::DateTime;
+use pgtemp::{PgTempDB, PgTempDBBuilder};
+use rust_decimal::Decimal;
+
+pub(crate) struct TestDb {
+    pub(crate) db: Db,
+    // Hold the temp_db in scope — dropping it stops the ephemeral Postgres instance.
+    pub(crate) _temp_db: PgTempDB,
+}
+
+pub(crate) async fn get_db() -> TestDb {
+    let temp_db = PgTempDBBuilder::new().start_async().await;
+    let db = Db::new(temp_db.connection_uri().as_str(), "./migrations")
+        .await
+        .unwrap();
+    TestDb {
+        db,
+        _temp_db: temp_db,
+    }
+}
+
+pub(crate) fn sample_operator(operator_id: u64) -> UpsertOperator {
+    UpsertOperator {
+        operator_id,
+        domain_id: 0,
+        owner_account: format!("owner_{operator_id}"),
+        signing_key: format!("0xsigning_key_{operator_id}"),
+        minimum_nominator_stake: 1_000_000_000_000_000_000,
+        nomination_tax: 5,
+        status: "registered".to_string(),
+        total_stake: 50_000_000_000_000_000_000,
+        total_shares: 50_000_000_000_000_000_000,
+        total_storage_fee_deposit: 1_000_000_000_000_000_000,
+        block_time: DateTime::from_timestamp_millis(1_700_000_000_000).unwrap(),
+    }
+}
+
+pub(crate) fn sample_share_price(
+    operator_id: i64,
+    epoch_index: i64,
+    block_height: i64,
+) -> UpsertSharePrice {
+    UpsertSharePrice {
+        operator_id,
+        domain_id: 0,
+        epoch_index,
+        share_price: Decimal::new(1_000_000_000_000_000_000, 18), // 1.0
+        total_stake: 50_000_000_000_000_000_000,
+        total_shares: 50_000_000_000_000_000_000,
+        block_height,
+        block_time: DateTime::from_timestamp_millis(1_700_000_000_000 + epoch_index * 60_000)
+            .unwrap(),
+    }
+}


### PR DESCRIPTION
- Add tracing::warn! to 4 silent Err(_) => continue paths in staking.rs so operator data gaps are visible in logs
- Extract TestDb, get_db(), sample_operator(), sample_share_price() into test_utils.rs to eliminate duplication between staking and storage tests
- Remove unnecessary #[allow(dead_code)] on OperatorStatusCompact
- Discard unused InvalidBundle hash data during SCALE decode