### PR TITLE
fix: bound Subspace::new_from_url with startup connect timeout (1.2.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "alerter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap",
  "env_logger",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "indexer"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "actix-cors",
  "actix-web",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["Subspace Labs <https://subspace.network>"]
 homepage = "https://subspace.network"

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     SubscriptionClosed,
     #[error("RPC error: {0}")]
     Rpc(#[from] subxt_rpcs::Error),
+    #[error("Timed out establishing initial RPC connection")]
+    ConnectTimeout,
     #[error("Block Hash missing from Cache")]
     MissingBlockHashFromCache(H256),
     #[error("Block body missing: {0}")]

--- a/shared/src/subspace.rs
+++ b/shared/src/subspace.rs
@@ -11,6 +11,7 @@ use sp_runtime::traits::{BlakeTwo256, Block as BlockT, Header as HeaderT};
 use sp_runtime::{OpaqueExtrinsic, generic};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
+use std::time::Duration;
 use subxt::backend::BackendExt;
 use subxt::client::ClientRuntimeUpdater;
 use subxt::config::substrate::SubstrateHeader;
@@ -299,6 +300,17 @@ pub struct BlocksExt {
 /// Maximum number of headers to load in the cache.
 const CACHE_HEADER_DEPTH: u32 = 100;
 
+/// Bound on the initial RPC connect inside `Subspace::new_from_url`. Prevents
+/// the binary from zombieing at startup if the upstream substrate RPC is
+/// unreachable: subxt's `ReconnectingRpcClient` retries the *initial* connect
+/// with an unbounded `ExponentialBackoff`, so without this guard the future
+/// never resolves and docker's `restart: unless-stopped` never fires. After
+/// the timeout, `new_from_url` returns `Err(Error::ConnectTimeout)`, `main()`
+/// exits non-zero, and the container restart loop takes over until the RPC
+/// is reachable. 60s is long enough to absorb a slow handshake and short
+/// enough to recycle within the first Uptime Kuma alert window.
+const STARTUP_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Overarching Subspace network wrapper
 /// for listening blocks, read storages etc..
 pub struct Subspace {
@@ -319,6 +331,12 @@ pub struct NetworkDetails {
 
 impl Subspace {
     pub async fn new_from_url(url: &str) -> Result<Self, Error> {
+        tokio::time::timeout(STARTUP_CONNECT_TIMEOUT, Self::connect(url))
+            .await
+            .map_err(|_| Error::ConnectTimeout)?
+    }
+
+    async fn connect(url: &str) -> Result<Self, Error> {
         let rpc_client = RpcClient::new(
             subxt_rpcs::client::ReconnectingRpcClient::builder()
                 .build(url)


### PR DESCRIPTION
The mainnet chain-indexer hung for 41 hours on May 6 because `Subspace::new_from_url` blocks indefinitely when the substrate RPC is unreachable at startup. subxt's `ReconnectingRpcClient` retries the initial connect with an unbounded `ExponentialBackoff`, so the future never resolves and docker's `restart: unless-stopped` can't recover — the process never exits. The only output during the dead window was the db.pool metrics emitter holding an `Arc<Pool>` from the prior init, which kept the runtime non-empty.

This wraps the body in `tokio::time::timeout(60s)` and surfaces a new `Error::ConnectTimeout`. After the timeout, `main()` returns non-zero and docker keeps cycling restarts until the RPC comes back, which matches the self-healing behaviour the 11 prior restarts on May 6 already demonstrated. The bug was that one specific await could trap the process and short-circuit the restart loop. 60s is long enough for a slow handshake and short enough to recycle within the first Uptime Kuma alert window.

The fix lives in `shared/` so both the indexer and the alerter pick it up via their shared startup path.

Patch bump 1.2.0 → 1.2.1; tagging `v1.2.1` after merge triggers the release pipeline added in #116.